### PR TITLE
ALI-1427 handle windows ai nav config path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
   "ruamel.yaml",
   "openai",
   "platformdirs",
-  "packaging"
+  "packaging",
+  "click <8.2"
 ]
 description = "Download and launch curated models from Anaconda"
 dynamic = ["version"]

--- a/src/anaconda_ai/config.py
+++ b/src/anaconda_ai/config.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Any
 from typing import Literal
 
-import platform
 import platformdirs
 from pydantic import BaseModel
 
@@ -19,11 +18,8 @@ class AINavigatorConfig(BaseModel):
 
     @property
     def config_file(self) -> Path:
-        if platform.system() == "Windows":
-            # For Windows, use the roaming app data directory and do not include "author" in the path
-            base_dir = Path(platformdirs.user_data_dir(self.app_name, False, roaming=True))
-        else:
-            base_dir = Path(platformdirs.user_data_dir(self.app_name))
+        # For Windows, use the roaming app data directory and do not include "author" in the path
+        base_dir = Path(platformdirs.user_data_dir(self.app_name, False, roaming=True))
 
         return base_dir / "config.json"
 

--- a/src/anaconda_ai/config.py
+++ b/src/anaconda_ai/config.py
@@ -18,7 +18,8 @@ class AINavigatorConfig(BaseModel):
 
     @property
     def config_file(self) -> Path:
-        return Path(platformdirs.user_data_dir(self.app_name)) / "config.json"
+        # For Windows, use the roaming app data directory and do not include "author" in the path
+        return Path(platformdirs.user_data_dir(self.app_name, False, roaming=True)) / "config.json"
 
     def get_config(self, key: str) -> Any:
         with self.config_file.open("r") as f:

--- a/src/anaconda_ai/config.py
+++ b/src/anaconda_ai/config.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Any
 from typing import Literal
 
+import platform
 import platformdirs
 from pydantic import BaseModel
 
@@ -18,8 +19,13 @@ class AINavigatorConfig(BaseModel):
 
     @property
     def config_file(self) -> Path:
-        # For Windows, use the roaming app data directory and do not include "author" in the path
-        return Path(platformdirs.user_data_dir(self.app_name, False, roaming=True)) / "config.json"
+        if platform.system() == "Windows":
+            # For Windows, use the roaming app data directory and do not include "author" in the path
+            base_dir = Path(platformdirs.user_data_dir(self.app_name, False, roaming=True))
+        else:
+            base_dir = Path(platformdirs.user_data_dir(self.app_name))
+
+        return base_dir / "config.json"
 
     def get_config(self, key: str) -> Any:
         with self.config_file.open("r") as f:


### PR DESCRIPTION
[ALI-1427](https://anaconda.atlassian.net/browse/AIL-1427)

Fixes Windows AI Navigator path by:
- Turning off "author" directory
- Use Roaming data instead of Local

Tested and working in the cases described in the JIRA ticket.