### PR TITLE
feat(anaconda-ai): [AIC-3028] Add automation coverage for download command

### DIFF
--- a/tests/e2e/pages/cli/anaconda-ai-cmds.ts
+++ b/tests/e2e/pages/cli/anaconda-ai-cmds.ts
@@ -49,23 +49,19 @@ export class AnacondaAiCli {
 
   // Validates model download started or completed successfully
   public verifyDownloadModelCommand(result: ShellResult): void {
-    expect(
-      result.exitCode,
-      `Expected download command to exit with code 0, but got ${result.exitCode}`,
-    ).toBe(0);
-    const output = result.output.toLowerCase();
-   
+    verifyShellExitCode(result, 'anaconda ai download <model>/<quant>');
+
+    const output = stripAnsiSgrAndTrim(result.output).toLowerCase();
     const isDownloadedNow =
       output.includes('downloading') &&
       (output.includes('mb') || output.includes('.gguf')) &&
       output.includes('success');
     const isAlreadyDownloaded = output.includes('success');
 
-    expect
-      .soft(
-        isDownloadedNow || isAlreadyDownloaded,
-        'Expected the model to be either newly downloaded or already downloaded',
-      )
+    expect(
+      isDownloadedNow || isAlreadyDownloaded,
+      'Expected the model to be either newly downloaded or already downloaded',
+    )
       .toBeTruthy();
   }
 

--- a/tests/e2e/pages/cli/anaconda-ai-cmds.ts
+++ b/tests/e2e/pages/cli/anaconda-ai-cmds.ts
@@ -1,4 +1,4 @@
-import { shellCommand, verifyShellExitCode, type ShellResult } from 'tests/utils/CliUtils';
+import { shellCommand, stripAnsiSgrAndTrim, verifyShellExitCode, type ShellResult } from 'tests/utils/CliUtils';
 import * as cliCommands from './cliCommands';
 import { expect } from 'tests/test-setup/page-setup';
 import { ModelApi } from '@testdata/model-api';
@@ -25,7 +25,7 @@ export class AnacondaAiCli {
   public verifyAnacondaAiModelsListCommand(result: ShellResult): void {
     verifyShellExitCode(result, 'anaconda ai models --json');
 
-    const models = JSON.parse(result.output) as ModelApi[];
+    const models = JSON.parse(stripAnsiSgrAndTrim(result.output)) as ModelApi[];
     expect(
       Array.isArray(models) && models.length,
       'models output should be a non-empty array',
@@ -37,9 +37,36 @@ export class AnacondaAiCli {
   public verifyAnacondaAiBlockedModelsListCommand(result: ShellResult): void {
     verifyShellExitCode(result, 'anaconda ai models --show-blocked --json');
 
-    const models = JSON.parse(result.output) as ModelApi[];
+    const models = JSON.parse(stripAnsiSgrAndTrim(result.output)) as ModelApi[];
     expect(Array.isArray(models), 'blocked models output should be an array').toBe(true);
     this.assertModelResponseData(models);
+  }
+
+  // Executes `anaconda ai download <model>/<quant>` (positional; no --model)
+  public async runDownloadModelCommand(modelName: string, modelQuantization: string): Promise<ShellResult> {
+    return await shellCommand(cliCommands.downloadModelCmd(modelName, modelQuantization));
+  }
+
+  // Validates model download started or completed successfully
+  public verifyDownloadModelCommand(result: ShellResult): void {
+    expect(
+      result.exitCode,
+      `Expected download command to exit with code 0, but got ${result.exitCode}`,
+    ).toBe(0);
+    const output = result.output.toLowerCase();
+   
+    const isDownloadedNow =
+      output.includes('downloading') &&
+      (output.includes('mb') || output.includes('.gguf')) &&
+      output.includes('success');
+    const isAlreadyDownloaded = output.includes('success');
+
+    expect
+      .soft(
+        isDownloadedNow || isAlreadyDownloaded,
+        'Expected the model to be either newly downloaded or already downloaded',
+      )
+      .toBeTruthy();
   }
 
   private assertModelResponseData(models: ModelApi[]): void {

--- a/tests/e2e/pages/cli/cliCommands.ts
+++ b/tests/e2e/pages/cli/cliCommands.ts
@@ -34,3 +34,7 @@ export const anacondaAiModelsListCmd = condaRun('anaconda ai models --json');
 export const anacondaAiBlockedModelsListCmd = condaRun(
   'anaconda ai models --show-blocked --json',
 );
+
+// Download Model Command
+export const downloadModelCmd = (modelName: string, modelQuantization: string): string =>
+  condaRun(`anaconda ai download ${modelName}/${modelQuantization}`);

--- a/tests/e2e/specs/cli/anaconda-ai.spec.ts
+++ b/tests/e2e/specs/cli/anaconda-ai.spec.ts
@@ -1,4 +1,5 @@
 import { test } from '@fixture';
+import { DOWNLOAD_TEST_MODEL_NAME, DOWNLOAD_TEST_MODEL_QUANTIZATION } from '@testdata/model-api';
 
 test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
   test('anaconda ai --help', async ({ anacondaAiCli }) => {
@@ -13,5 +14,13 @@ test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
   test('anaconda ai models list blocked command', async ({ anacondaAiCli }) => {
     const result = await anacondaAiCli.runAnacondaAiBlockedModelsListCommand();
     anacondaAiCli.verifyAnacondaAiBlockedModelsListCommand(result);
+  });
+
+  test('anaconda ai download model command', async ({ anacondaAiCli }) => {
+    const result = await anacondaAiCli.runDownloadModelCommand(
+      DOWNLOAD_TEST_MODEL_NAME,
+      DOWNLOAD_TEST_MODEL_QUANTIZATION,
+    );
+    anacondaAiCli.verifyDownloadModelCommand(result);
   });
 });

--- a/tests/e2e/testdata/model-api.ts
+++ b/tests/e2e/testdata/model-api.ts
@@ -13,3 +13,7 @@ export type ModelApi = {
   trained_for: string;
 };
 
+// Data to verify the Download Model Command
+export const DOWNLOAD_TEST_MODEL_NAME = 'bge-base-en-v1.5';
+export const DOWNLOAD_TEST_MODEL_QUANTIZATION = 'q4_k_m';
+

--- a/tests/utils/CliUtils.ts
+++ b/tests/utils/CliUtils.ts
@@ -9,6 +9,11 @@ export interface ShellResult {
   stderrOutput: string;
 }
 
+// Strip ANSI SGR color sequences (ESC [ … m) and trim — use before parsing CLI stdout/stderr.
+export function stripAnsiSgrAndTrim(output: string): string {
+  return output.replace(/\x1B\[[0-9;]*m/g, '').trim();
+}
+
 /** Asserts a shell command exited 0; logs stderr/output on failure. */
 export function verifyShellExitCode(result: ShellResult, commandName: string): void {
   if (result.exitCode !== 0) {


### PR DESCRIPTION
Added automation coverage for the anaconda ai download command in the CLI test suite.

Changes
added downloadModelCmd() for running the download command with model name and quantization
added CLI test coverage for anaconda ai download <model>/<quant>
added verification for successful download command execution
handled ANSI-colored CLI output before JSON parsing in model list and blocked model list validations
added download test data for model name and quantization
added reusable helper stripAnsiSgrAndTrim() in CliUtils
Validation
verifies the download command exits successfully
verifies the output indicates either:
the model started/completed downloading successfully, or
the model is already downloaded
ensures model list and blocked model list parsing remains stable even when CLI output contains ANSI color codes