### PR TITLE
test(anaconda-ai): [AIC-3045] add CLI coverage for invalid download and servers list commands

### DIFF
--- a/tests/e2e/pages/cli/anaconda-ai-cmds.ts
+++ b/tests/e2e/pages/cli/anaconda-ai-cmds.ts
@@ -1,7 +1,7 @@
 import { shellCommand, stripAnsiSgrAndTrim, verifyShellExitCode, type ShellResult } from 'tests/utils/CliUtils';
 import * as cliCommands from './cliCommands';
 import { expect } from 'tests/test-setup/page-setup';
-import { ModelApi } from '@testdata/model-api';
+import { INVALID_MODEL_ERROR_MESSAGE, ModelApi, ServerApi } from '@testdata/model-api';
 
 // CLI helpers for Anaconda AI package CLI commands.
 export class AnacondaAiCli {
@@ -65,6 +65,13 @@ export class AnacondaAiCli {
       .toBeTruthy();
   }
 
+  public verifyInvalidDownloadModelCommand(result: ShellResult): void {
+    expect(result.exitCode, `Expected invalid download command to fail, but got exit code ${result.exitCode}`,).not.toBe(0);
+    const output = stripAnsiSgrAndTrim(result.output).toLowerCase();
+    expect(output, 'Expected the model to be invalid').toContain('error');
+    expect(output, 'Expected the error message to be invalid').toContain(INVALID_MODEL_ERROR_MESSAGE);
+  }
+
   private assertModelResponseData(models: ModelApi[]): void {
     models.forEach((model, modelIndex) => {
       expect(model.model, `models[${modelIndex}].model should be defined`).toBeDefined();
@@ -82,4 +89,15 @@ export class AnacondaAiCli {
       });
     });
   }
+
+  public async runAnacondaAiServersListCommand(): Promise<ShellResult> {
+    return await shellCommand(cliCommands.anacondaAiServersListCmd);
+  }
+
+  public verifyAnacondaAiServersListCommand(result: ShellResult): void {
+    verifyShellExitCode(result, 'anaconda ai servers --json');
+
+    const servers = JSON.parse(stripAnsiSgrAndTrim(result.output)) as ServerApi[];
+    expect(Array.isArray(servers), 'servers output should be an array').toBe(true);
+  } 
 }

--- a/tests/e2e/pages/cli/cliCommands.ts
+++ b/tests/e2e/pages/cli/cliCommands.ts
@@ -29,6 +29,7 @@ export const authWhoamiCmd = condaRun('anaconda auth whoami');
 
 export const anacondaAiHelpCmd = condaRun('anaconda ai --help');
 
+// Anaconda AI Models Command
 export const anacondaAiModelsListCmd = condaRun('anaconda ai models --json');
 
 export const anacondaAiBlockedModelsListCmd = condaRun(
@@ -38,3 +39,6 @@ export const anacondaAiBlockedModelsListCmd = condaRun(
 // Download Model Command
 export const downloadModelCmd = (modelName: string, modelQuantization: string): string =>
   condaRun(`anaconda ai download ${modelName}/${modelQuantization}`);
+
+// Anaconda AI Servers Command
+export const anacondaAiServersListCmd = condaRun('anaconda ai servers --json');

--- a/tests/e2e/specs/cli/anaconda-ai.spec.ts
+++ b/tests/e2e/specs/cli/anaconda-ai.spec.ts
@@ -1,5 +1,5 @@
 import { test } from '@fixture';
-import { DOWNLOAD_TEST_MODEL_NAME, DOWNLOAD_TEST_MODEL_QUANTIZATION } from '@testdata/model-api';
+import { DOWNLOAD_TEST_MODEL_NAME, DOWNLOAD_TEST_MODEL_QUANTIZATION, INVALID_MODEL_NAME, INVALID_MODEL_QUANTIZATION } from '@testdata/model-api';
 
 test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
   test('anaconda ai --help', async ({ anacondaAiCli }) => {
@@ -23,4 +23,18 @@ test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
     );
     anacondaAiCli.verifyDownloadModelCommand(result);
   });
+
+  test('anaconda ai download invalid model command', async ({ anacondaAiCli }) => {
+    const result = await anacondaAiCli.runDownloadModelCommand(
+      INVALID_MODEL_NAME,
+      INVALID_MODEL_QUANTIZATION,
+    );
+    anacondaAiCli.verifyInvalidDownloadModelCommand(result);
+  });
+
+  test('anaconda ai servers list command', async ({ anacondaAiCli }) => {
+    const result = await anacondaAiCli.runAnacondaAiServersListCommand();
+    anacondaAiCli.verifyAnacondaAiServersListCommand(result);
+  });
+
 });

--- a/tests/e2e/testdata/model-api.ts
+++ b/tests/e2e/testdata/model-api.ts
@@ -6,6 +6,7 @@ export type ModelQuantization = {
   blocked: boolean;
 };
 
+// Types for `anaconda ai models --json` CLI output
 export type ModelApi = {
   model: string;
   parameters: number;
@@ -13,7 +14,19 @@ export type ModelApi = {
   trained_for: string;
 };
 
+// Types for `anaconda ai servers --json` CLI output
+export type ServerApi = {
+  server_id: string;
+  model: string;
+  status: string;
+};
+
 // Data to verify the Download Model Command
 export const DOWNLOAD_TEST_MODEL_NAME = 'bge-base-en-v1.5';
 export const DOWNLOAD_TEST_MODEL_QUANTIZATION = 'q4_k_m';
+
+// invalid model data
+export const INVALID_MODEL_NAME = 'invalid-model';
+export const INVALID_MODEL_QUANTIZATION = 'invalid-quantization';
+export const INVALID_MODEL_ERROR_MESSAGE = 'you must include the quantization method in the model';
 


### PR DESCRIPTION
Adds CLI automation coverage for:

invalid anaconda ai download <model>/<quant> command validation
anaconda ai servers --json command validation

Changes
added invalid download command test using invalid model and quantization
added verifyInvalidDownloadModelCommand() to validate failure behavior and expected error message
added ServerApi type for anaconda ai servers --json response
added runAnacondaAiServersListCommand() and verifyAnacondaAiServersListCommand()
added anacondaAiServersListCmd CLI command helper
updated test data with invalid model constants and expected invalid error message

Validation
verifies valid download command behavior
verifies invalid download command fails with expected error text
verifies anaconda ai servers --json exits successfully
verifies servers command output is a valid array