### PR TITLE
test(anaconda-ai): add e2e CLI tests for anaconda ai server lifecycle and negative cases

### DIFF
--- a/tests/e2e/pages/cli/anaconda-ai-cmds.ts
+++ b/tests/e2e/pages/cli/anaconda-ai-cmds.ts
@@ -98,8 +98,8 @@ export class AnacondaAiCli {
     const expectedModelFile = `${modelName}_${modelQuantization}.gguf`.toLowerCase();
     expect(output.includes('running'), 'Expected status to be "running"').toBeTruthy();
     expect(
-      output.includes('openai compatible url'),
-      'Expected "OpenAI Compatible URL" field in output',
+      output.includes('inference/serve/'),
+      'Expected "inference/serve/" is running',
     ).toBeTruthy();
     expect(
       output.includes(expectedModelFile),
@@ -145,11 +145,6 @@ export class AnacondaAiCli {
     ).toBeTruthy();
   }
 
-  // Executes `anaconda ai launch abc` (missing slash — invalid format)
-  public async runLaunchModelInvalidFormatCommand(): Promise<ShellResult> {
-    return await shellCommand(cliCommands.launchModelInvalidFormatCmd);
-  }
-
   // Validates that launching with an invalid format exits non-zero with a ValueError
   public verifyLaunchModelInvalidFormatCommand(result: ShellResult): void {
     expect(result.exitCode, 'Expected non-zero exit code for invalid format').not.toBe(0);
@@ -159,11 +154,6 @@ export class AnacondaAiCli {
       output.includes('valueerror') && output.includes('does not look like a quantized model name'),
       'Expected ValueError about invalid model name format',
     ).toBeTruthy();
-  }
-
-  // Executes `anaconda ai launch nonexistent-model/q4_k_m` (valid format, unknown model)
-  public async runLaunchModelNotFoundCommand(): Promise<ShellResult> {
-    return await shellCommand(cliCommands.launchModelNotFoundCmd);
   }
 
   // Validates that launching an unknown model exits non-zero with a ModelNotFound error

--- a/tests/e2e/pages/cli/anaconda-ai-cmds.ts
+++ b/tests/e2e/pages/cli/anaconda-ai-cmds.ts
@@ -53,6 +53,20 @@ export class AnacondaAiCli {
     expect(Array.isArray(servers), 'servers output should be an array').toBe(true);
   }
 
+  // Verifies that a server for the given model appears in the servers list with status "running"
+  public verifyRunningServerInList(result: ShellResult, modelName: string, modelQuantization: string): void {
+    verifyShellExitCode(result, 'anaconda ai servers --json');
+
+    const servers = JSON.parse(stripAnsiSgrAndTrim(result.output)) as ServerApi[];
+    const expectedModelFile = `${modelName}_${modelQuantization}.gguf`;
+    const server = servers.find((s) => s.model === expectedModelFile);
+
+    expect(server, `Expected server for model "${expectedModelFile}" to appear in servers list`).toBeDefined();
+    expect(server!.server_id, `Expected server_id to contain model name "${modelName}"`).toContain(modelName);
+    expect(server!.model, `Expected model to be "${expectedModelFile}"`).toBe(expectedModelFile);
+    expect(server!.status, `Expected server status to be "running"`).toBe('running');
+  }
+
   // Executes `anaconda ai download <model>/<quant>` (positional; no --model)
   public async runDownloadModelCommand(modelName: string, modelQuantization: string): Promise<ShellResult> {
     return await shellCommand(cliCommands.downloadModelCmd(modelName, modelQuantization));
@@ -82,12 +96,23 @@ export class AnacondaAiCli {
     ).not.toBe(0);
     const output = stripAnsiSgrAndTrim(result.output).toLowerCase();
     expect(output, 'Expected the model to be invalid').toContain('error');
-    expect(output, 'Expected the error message to be invalid').toContain(INVALID_MODEL_ERROR_MESSAGE);
+    expect(output, 'Expected output should contain invalid model error message').toContain(INVALID_MODEL_ERROR_MESSAGE);
   }
 
   // Executes `anaconda ai launch <model>/<quant> --detach`
   public async runLaunchModelCommand(modelName: string, modelQuantization: string): Promise<ShellResult> {
     return await shellCommand(cliCommands.launchModelCmd(modelName, modelQuantization));
+  }
+
+  // Validates that launching a model that already has a running server fails with AnacondaAIException
+  public verifyDuplicateLaunchModelCommand(result: ShellResult): void {
+    expect(result.exitCode, 'Expected non-zero exit code for duplicate launch').not.toBe(0);
+
+    const output = stripAnsiSgrAndTrim(result.output).toLowerCase();
+    expect(
+      output.includes('anacondaaiexception') || output.includes('already exists'),
+      'Expected AnacondaAIException about duplicate server',
+    ).toBeTruthy();
   }
 
   // Validates model server launched successfully

--- a/tests/e2e/pages/cli/anaconda-ai-cmds.ts
+++ b/tests/e2e/pages/cli/anaconda-ai-cmds.ts
@@ -42,6 +42,17 @@ export class AnacondaAiCli {
     this.assertModelResponseData(models);
   }
 
+  public async runAnacondaAiServersListCommand(): Promise<ShellResult> {
+    return await shellCommand(cliCommands.anacondaAiServersListCmd);
+  }
+
+  public verifyAnacondaAiServersListCommand(result: ShellResult): void {
+    verifyShellExitCode(result, 'anaconda ai servers --json');
+
+    const servers = JSON.parse(stripAnsiSgrAndTrim(result.output)) as ServerApi[];
+    expect(Array.isArray(servers), 'servers output should be an array').toBe(true);
+  }
+
   // Executes `anaconda ai download <model>/<quant>` (positional; no --model)
   public async runDownloadModelCommand(modelName: string, modelQuantization: string): Promise<ShellResult> {
     return await shellCommand(cliCommands.downloadModelCmd(modelName, modelQuantization));
@@ -61,15 +72,109 @@ export class AnacondaAiCli {
     expect(
       isDownloadedNow || isAlreadyDownloaded,
       'Expected the model to be either newly downloaded or already downloaded',
-    )
-      .toBeTruthy();
+    ).toBeTruthy();
   }
 
   public verifyInvalidDownloadModelCommand(result: ShellResult): void {
-    expect(result.exitCode, `Expected invalid download command to fail, but got exit code ${result.exitCode}`,).not.toBe(0);
+    expect(
+      result.exitCode,
+      `Expected invalid download command to fail, but got exit code ${result.exitCode}`,
+    ).not.toBe(0);
     const output = stripAnsiSgrAndTrim(result.output).toLowerCase();
     expect(output, 'Expected the model to be invalid').toContain('error');
     expect(output, 'Expected the error message to be invalid').toContain(INVALID_MODEL_ERROR_MESSAGE);
+  }
+
+  // Executes `anaconda ai launch <model>/<quant> --detach`
+  public async runLaunchModelCommand(modelName: string, modelQuantization: string): Promise<ShellResult> {
+    return await shellCommand(cliCommands.launchModelCmd(modelName, modelQuantization));
+  }
+
+  // Validates model server launched successfully
+  public verifyLaunchModelCommand(result: ShellResult, modelName: string, modelQuantization: string): void {
+    verifyShellExitCode(result, 'anaconda ai launch <model>/<quant>');
+
+    const output = stripAnsiSgrAndTrim(result.output).toLowerCase();
+    const expectedModelFile = `${modelName}_${modelQuantization}.gguf`.toLowerCase();
+    expect(output.includes('running'), 'Expected status to be "running"').toBeTruthy();
+    expect(
+      output.includes('openai compatible url'),
+      'Expected "OpenAI Compatible URL" field in output',
+    ).toBeTruthy();
+    expect(
+      output.includes(expectedModelFile),
+      `Expected model "${expectedModelFile}" to appear in output`,
+    ).toBeTruthy();
+  }
+
+  // Executes `anaconda ai stop <modelName>_<modelQuantization>.gguf`
+  public async runStopModelCommand(modelName: string, modelQuantization: string): Promise<ShellResult> {
+    return await shellCommand(cliCommands.stopModelCmd(modelName, modelQuantization));
+  }
+
+  // Validates model server stopped successfully
+  public verifyStopModelCommand(result: ShellResult, modelName: string, modelQuantization: string): void {
+    verifyShellExitCode(result, 'anaconda ai stop <model>.gguf');
+
+    const output = stripAnsiSgrAndTrim(result.output).toLowerCase();
+    const expectedModelFile = `${modelName}_${modelQuantization}.gguf`.toLowerCase();
+    expect(output.includes('stopped'), 'Expected status to be "stopped"').toBeTruthy();
+    expect(output.includes('success'), 'Expected "Success" in output').toBeTruthy();
+    expect(
+      output.includes(expectedModelFile),
+      `Expected model "${expectedModelFile}" to appear in output`,
+    ).toBeTruthy();
+  }
+
+  // Executes `anaconda ai stop <modelName>_<modelQuantization>.gguf --rm`
+  public async runStopAndRemoveModelCommand(modelName: string, modelQuantization: string): Promise<ShellResult> {
+    return await shellCommand(cliCommands.stopAndRemoveModelCmd(modelName, modelQuantization));
+  }
+
+  // Validates model server deleted successfully
+  public verifyStopAndRemoveModelCommand(result: ShellResult, modelName: string, modelQuantization: string): void {
+    verifyShellExitCode(result, 'anaconda ai stop <model>.gguf --rm');
+
+    const output = stripAnsiSgrAndTrim(result.output).toLowerCase();
+    const expectedModelFile = `${modelName}_${modelQuantization}.gguf`.toLowerCase();
+    expect(output.includes('deleted'), 'Expected status to be "deleted"').toBeTruthy();
+    expect(output.includes('success'), 'Expected "Success" in output').toBeTruthy();
+    expect(
+      output.includes(expectedModelFile),
+      `Expected model "${expectedModelFile}" to appear in output`,
+    ).toBeTruthy();
+  }
+
+  // Executes `anaconda ai launch abc` (missing slash — invalid format)
+  public async runLaunchModelInvalidFormatCommand(): Promise<ShellResult> {
+    return await shellCommand(cliCommands.launchModelInvalidFormatCmd);
+  }
+
+  // Validates that launching with an invalid format exits non-zero with a ValueError
+  public verifyLaunchModelInvalidFormatCommand(result: ShellResult): void {
+    expect(result.exitCode, 'Expected non-zero exit code for invalid format').not.toBe(0);
+
+    const output = stripAnsiSgrAndTrim(result.output).toLowerCase();
+    expect(
+      output.includes('valueerror') && output.includes('does not look like a quantized model name'),
+      'Expected ValueError about invalid model name format',
+    ).toBeTruthy();
+  }
+
+  // Executes `anaconda ai launch nonexistent-model/q4_k_m` (valid format, unknown model)
+  public async runLaunchModelNotFoundCommand(): Promise<ShellResult> {
+    return await shellCommand(cliCommands.launchModelNotFoundCmd);
+  }
+
+  // Validates that launching an unknown model exits non-zero with a ModelNotFound error
+  public verifyLaunchModelNotFoundCommand(result: ShellResult): void {
+    expect(result.exitCode, 'Expected non-zero exit code for unknown model').not.toBe(0);
+
+    const output = stripAnsiSgrAndTrim(result.output).toLowerCase();
+    expect(
+      output.includes('modelnotfound') || output.includes('was not found'),
+      'Expected ModelNotFound error for unknown model',
+    ).toBeTruthy();
   }
 
   private assertModelResponseData(models: ModelApi[]): void {
@@ -89,15 +194,4 @@ export class AnacondaAiCli {
       });
     });
   }
-
-  public async runAnacondaAiServersListCommand(): Promise<ShellResult> {
-    return await shellCommand(cliCommands.anacondaAiServersListCmd);
-  }
-
-  public verifyAnacondaAiServersListCommand(result: ShellResult): void {
-    verifyShellExitCode(result, 'anaconda ai servers --json');
-
-    const servers = JSON.parse(stripAnsiSgrAndTrim(result.output)) as ServerApi[];
-    expect(Array.isArray(servers), 'servers output should be an array').toBe(true);
-  } 
 }

--- a/tests/e2e/pages/cli/cliCommands.ts
+++ b/tests/e2e/pages/cli/cliCommands.ts
@@ -47,12 +47,6 @@ export const anacondaAiServersListCmd = condaRun('anaconda ai servers --json');
 export const launchModelCmd = (modelName: string, modelQuantization: string): string =>
   condaRun(`anaconda ai launch ${modelName}/${modelQuantization} --detach`);
 
-// Negative: input missing the slash — triggers ValueError (invalid format)
-export const launchModelInvalidFormatCmd = condaRun('anaconda ai launch abc');
-
-// Negative: valid format but non-existent model — triggers ModelNotFound
-export const launchModelNotFoundCmd = condaRun('anaconda ai launch nonexistent-model/q4_k_m');
-
 // Stop server for model command — takes the .gguf filename: <modelName>_<modelQuantization>.gguf
 export const stopModelCmd = (modelName: string, modelQuantization: string): string =>
   condaRun(`anaconda ai stop ${modelName}_${modelQuantization}.gguf`);

--- a/tests/e2e/pages/cli/cliCommands.ts
+++ b/tests/e2e/pages/cli/cliCommands.ts
@@ -42,3 +42,21 @@ export const downloadModelCmd = (modelName: string, modelQuantization: string): 
 
 // Anaconda AI Servers Command
 export const anacondaAiServersListCmd = condaRun('anaconda ai servers --json');
+
+// Launch server for model command
+export const launchModelCmd = (modelName: string, modelQuantization: string): string =>
+  condaRun(`anaconda ai launch ${modelName}/${modelQuantization} --detach`);
+
+// Negative: input missing the slash — triggers ValueError (invalid format)
+export const launchModelInvalidFormatCmd = condaRun('anaconda ai launch abc');
+
+// Negative: valid format but non-existent model — triggers ModelNotFound
+export const launchModelNotFoundCmd = condaRun('anaconda ai launch nonexistent-model/q4_k_m');
+
+// Stop server for model command — takes the .gguf filename: <modelName>_<modelQuantization>.gguf
+export const stopModelCmd = (modelName: string, modelQuantization: string): string =>
+  condaRun(`anaconda ai stop ${modelName}_${modelQuantization}.gguf`);
+
+// Stop and remove server — same as stop but with --rm to delete it
+export const stopAndRemoveModelCmd = (modelName: string, modelQuantization: string): string =>
+  condaRun(`anaconda ai stop ${modelName}_${modelQuantization}.gguf --rm`);

--- a/tests/e2e/specs/cli/anaconda-ai.spec.ts
+++ b/tests/e2e/specs/cli/anaconda-ai.spec.ts
@@ -45,11 +45,11 @@ test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
 
   test('anaconda ai launch, stop model command', async ({ anacondaAiCli }) => {
     await test.step('launch model server', async () => {
-      const result = await anacondaAiCli.runLaunchModelCommand(
+      const launchResult = await anacondaAiCli.runLaunchModelCommand(
         DOWNLOAD_TEST_MODEL_NAME,
         DOWNLOAD_TEST_MODEL_QUANTIZATION,
       );
-      anacondaAiCli.verifyLaunchModelCommand(result, DOWNLOAD_TEST_MODEL_NAME, DOWNLOAD_TEST_MODEL_QUANTIZATION);
+      anacondaAiCli.verifyLaunchModelCommand(launchResult, DOWNLOAD_TEST_MODEL_NAME, DOWNLOAD_TEST_MODEL_QUANTIZATION);
     });
 
     await test.step('stop model server', async () => {
@@ -70,12 +70,18 @@ test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
   });
 
   test('anaconda ai launch - invalid format returns ValueError', async ({ anacondaAiCli }) => {
-    const result = await anacondaAiCli.runLaunchModelInvalidFormatCommand();
+    const result = await anacondaAiCli.runLaunchModelCommand(
+      INVALID_MODEL_NAME,
+      INVALID_MODEL_QUANTIZATION,
+    );
     anacondaAiCli.verifyLaunchModelInvalidFormatCommand(result);
   });
 
   test('anaconda ai launch - unknown model returns ModelNotFound', async ({ anacondaAiCli }) => {
-    const result = await anacondaAiCli.runLaunchModelNotFoundCommand();
+    const result = await anacondaAiCli.runLaunchModelCommand(
+      INVALID_MODEL_NAME,
+      DOWNLOAD_TEST_MODEL_QUANTIZATION,
+    );
     anacondaAiCli.verifyLaunchModelNotFoundCommand(result);
   });
 });

--- a/tests/e2e/specs/cli/anaconda-ai.spec.ts
+++ b/tests/e2e/specs/cli/anaconda-ai.spec.ts
@@ -43,8 +43,8 @@ test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
     anacondaAiCli.verifyAnacondaAiServersListCommand(result);
   });
 
-  test('anaconda ai launch, stop model command', async ({ anacondaAiCli }) => {
-    await test.step('launch model server', async () => {
+  test('anaconda ai server lifecycle: launch, verify, stop, and delete a model server', async ({ anacondaAiCli }) => {
+    await test.step('step 1: launch model server and verify it is running', async () => {
       const launchResult = await anacondaAiCli.runLaunchModelCommand(
         DOWNLOAD_TEST_MODEL_NAME,
         DOWNLOAD_TEST_MODEL_QUANTIZATION,
@@ -52,7 +52,20 @@ test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
       anacondaAiCli.verifyLaunchModelCommand(launchResult, DOWNLOAD_TEST_MODEL_NAME, DOWNLOAD_TEST_MODEL_QUANTIZATION);
     });
 
-    await test.step('stop model server', async () => {
+    await test.step('step 2: verify server appears in servers list with status "running"', async () => {
+      const serversResult = await anacondaAiCli.runAnacondaAiServersListCommand();
+      anacondaAiCli.verifyRunningServerInList(serversResult, DOWNLOAD_TEST_MODEL_NAME, DOWNLOAD_TEST_MODEL_QUANTIZATION);
+    });
+
+    await test.step('step 3: launching the same server again returns AnacondaAIException', async () => {
+      const duplicateResult = await anacondaAiCli.runLaunchModelCommand(
+        DOWNLOAD_TEST_MODEL_NAME,
+        DOWNLOAD_TEST_MODEL_QUANTIZATION,
+      );
+      anacondaAiCli.verifyDuplicateLaunchModelCommand(duplicateResult);
+    });
+
+    await test.step('step 4: stop the model server and verify it is stopped', async () => {
       const stopResult = await anacondaAiCli.runStopModelCommand(
         DOWNLOAD_TEST_MODEL_NAME,
         DOWNLOAD_TEST_MODEL_QUANTIZATION,
@@ -60,7 +73,7 @@ test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
       anacondaAiCli.verifyStopModelCommand(stopResult, DOWNLOAD_TEST_MODEL_NAME, DOWNLOAD_TEST_MODEL_QUANTIZATION);
     });
 
-    await test.step('delete model server', async () => {
+    await test.step('step 5: delete the model server and verify it is removed', async () => {
       const deleteResult = await anacondaAiCli.runStopAndRemoveModelCommand(
         DOWNLOAD_TEST_MODEL_NAME,
         DOWNLOAD_TEST_MODEL_QUANTIZATION,

--- a/tests/e2e/specs/cli/anaconda-ai.spec.ts
+++ b/tests/e2e/specs/cli/anaconda-ai.spec.ts
@@ -1,11 +1,17 @@
 import { test } from '@fixture';
-import { DOWNLOAD_TEST_MODEL_NAME, DOWNLOAD_TEST_MODEL_QUANTIZATION, INVALID_MODEL_NAME, INVALID_MODEL_QUANTIZATION } from '@testdata/model-api';
+import {
+  DOWNLOAD_TEST_MODEL_NAME,
+  DOWNLOAD_TEST_MODEL_QUANTIZATION,
+  INVALID_MODEL_NAME,
+  INVALID_MODEL_QUANTIZATION,
+} from '@testdata/model-api';
 
 test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
   test('anaconda ai --help', async ({ anacondaAiCli }) => {
     const result = await anacondaAiCli.runAnacondaAiHelpCommand();
     anacondaAiCli.verifyAnacondaAiHelpCommand(result);
   });
+
   test('anaconda ai models list command', async ({ anacondaAiCli }) => {
     const result = await anacondaAiCli.runAnacondaAiModelsListCommand();
     anacondaAiCli.verifyAnacondaAiModelsListCommand(result);
@@ -37,4 +43,39 @@ test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
     anacondaAiCli.verifyAnacondaAiServersListCommand(result);
   });
 
+  test('anaconda ai launch, stop model command', async ({ anacondaAiCli }) => {
+    await test.step('launch model server', async () => {
+      const result = await anacondaAiCli.runLaunchModelCommand(
+        DOWNLOAD_TEST_MODEL_NAME,
+        DOWNLOAD_TEST_MODEL_QUANTIZATION,
+      );
+      anacondaAiCli.verifyLaunchModelCommand(result, DOWNLOAD_TEST_MODEL_NAME, DOWNLOAD_TEST_MODEL_QUANTIZATION);
+    });
+
+    await test.step('stop model server', async () => {
+      const stopResult = await anacondaAiCli.runStopModelCommand(
+        DOWNLOAD_TEST_MODEL_NAME,
+        DOWNLOAD_TEST_MODEL_QUANTIZATION,
+      );
+      anacondaAiCli.verifyStopModelCommand(stopResult, DOWNLOAD_TEST_MODEL_NAME, DOWNLOAD_TEST_MODEL_QUANTIZATION);
+    });
+
+    await test.step('delete model server', async () => {
+      const deleteResult = await anacondaAiCli.runStopAndRemoveModelCommand(
+        DOWNLOAD_TEST_MODEL_NAME,
+        DOWNLOAD_TEST_MODEL_QUANTIZATION,
+      );
+      anacondaAiCli.verifyStopAndRemoveModelCommand(deleteResult, DOWNLOAD_TEST_MODEL_NAME, DOWNLOAD_TEST_MODEL_QUANTIZATION);
+    });
+  });
+
+  test('anaconda ai launch - invalid format returns ValueError', async ({ anacondaAiCli }) => {
+    const result = await anacondaAiCli.runLaunchModelInvalidFormatCommand();
+    anacondaAiCli.verifyLaunchModelInvalidFormatCommand(result);
+  });
+
+  test('anaconda ai launch - unknown model returns ModelNotFound', async ({ anacondaAiCli }) => {
+    const result = await anacondaAiCli.runLaunchModelNotFoundCommand();
+    anacondaAiCli.verifyLaunchModelNotFoundCommand(result);
+  });
 });

--- a/tests/e2e/testdata/model-api.ts
+++ b/tests/e2e/testdata/model-api.ts
@@ -6,6 +6,7 @@ export type ModelQuantization = {
   blocked: boolean;
 };
 
+// Types for `anaconda ai models --json` CLI output
 export type ModelApi = {
   model: string;
   parameters: number;
@@ -24,7 +25,7 @@ export type ServerApi = {
 export const DOWNLOAD_TEST_MODEL_NAME = 'bge-base-en-v1.5';
 export const DOWNLOAD_TEST_MODEL_QUANTIZATION = 'q4_k_m';
 
-// Invalid model data
+// invalid model data
 export const INVALID_MODEL_NAME = 'invalid-model';
 export const INVALID_MODEL_QUANTIZATION = 'invalid-quantization';
 export const INVALID_MODEL_ERROR_MESSAGE = 'you must include the quantization method in the model';

--- a/tests/e2e/testdata/model-api.ts
+++ b/tests/e2e/testdata/model-api.ts
@@ -6,7 +6,6 @@ export type ModelQuantization = {
   blocked: boolean;
 };
 
-// Types for `anaconda ai models --json` CLI output
 export type ModelApi = {
   model: string;
   parameters: number;
@@ -25,8 +24,7 @@ export type ServerApi = {
 export const DOWNLOAD_TEST_MODEL_NAME = 'bge-base-en-v1.5';
 export const DOWNLOAD_TEST_MODEL_QUANTIZATION = 'q4_k_m';
 
-// invalid model data
+// Invalid model data
 export const INVALID_MODEL_NAME = 'invalid-model';
 export const INVALID_MODEL_QUANTIZATION = 'invalid-quantization';
 export const INVALID_MODEL_ERROR_MESSAGE = 'you must include the quantization method in the model';
-


### PR DESCRIPTION
## Ticket
[AIC-3046](https://anaconda.atlassian.net/browse/AIC-3046)

### Summary
Extends the Anaconda AI CLI e2e test suite to cover server lifecycle commands and error handling.

## New tests added:

- anaconda ai servers --json — verifies the servers list returns a valid JSON array
- anaconda ai launch <model>/<quant> --detach — verifies a model server starts with running status, OpenAI-compatible URL, and the expected model filename
- anaconda ai stop <model>.gguf — verifies the server stops and reports stopped + Success
- anaconda ai stop <model>.gguf --rm — verifies the server is deleted and reports deleted + Success
- anaconda ai launch abc (invalid format) — verifies non-zero exit code and ValueError with the correct error message
- anaconda ai launch nonexistent-model/q4_k_m (unknown model) — verifies non-zero exit code and ModelNotFound error

### Supporting changes:

- Added launchModelCmd, stopModelCmd, stopAndRemoveModelCmd, launchModelInvalidFormatCmd, launchModelNotFoundCmd to cliCommands.ts
- Added run/verify method pairs for all new commands to AnacondaAiCli in anaconda-ai-cmds.ts
- Added ServerApi type to model-api.ts
- Used test.step() in the launch/stop/delete test for clear failure attribution

[AIC-3046]: https://anaconda.atlassian.net/browse/AIC-3046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ