### PR TITLE
test(e2e): extend Anaconda AI CLI coverage and bump playwright-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "devDependencies": {
-        "@anaconda/playwright-utils": "1.2.4",
+        "@anaconda/playwright-utils": "1.3.6",
         "@playwright/test": "^1.49.0",
         "cross-env": "^7.0.3",
         "dotenv": "^16.4.5",
@@ -22,38 +22,42 @@
       }
     },
     "node_modules/@anaconda/playwright-utils": {
-      "version": "1.2.4",
-      "resolved": "https://npm.pkg.github.com/download/@anaconda/playwright-utils/1.2.4/69c04bb4cb316f55d5c62ba3ecee10d1c9c4c277",
-      "integrity": "sha512-NsLmVRj1GcrcRMxjOKJgWtAJR0GeFFawukFCoHVWqe9J5mUDdPC00mVf4vCBlm4OdxebjdsetaHYeXgUvjFcvA==",
+      "version": "1.3.6",
+      "resolved": "https://npm.pkg.github.com/download/@anaconda/playwright-utils/1.3.6/291eb0129cb1bcca6680e1f37cbe932e50faf58f",
+      "integrity": "sha512-C7RLPoI+V8gOyJqI1GUm4MWQRiLu2O0vk+Qk0R7FIiOqTHo5GVfZ9Glh49hAWvnoSkskaz3OgdcSkTQ/C6A6TQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@eslint/js": "^9.39.3",
-        "@types/node": "^25.3.2",
-        "@typescript-eslint/eslint-plugin": "^8.56.1",
-        "@typescript-eslint/parser": "^8.56.1",
+        "@eslint/js": "^9.39.4",
+        "@types/node": "^25.5.0",
+        "@typescript-eslint/eslint-plugin": "^8.57.2",
+        "@typescript-eslint/parser": "^8.57.2",
         "cross-env": "^10.1.0",
         "dotenv": "^17.3.1",
-        "eslint": "^9.39.3",
+        "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import": "^2.32.0",
-        "eslint-plugin-jsdoc": "^62.7.1",
-        "eslint-plugin-playwright": "^2.7.1",
+        "eslint-plugin-jsdoc": "^62.8.1",
+        "eslint-plugin-playwright": "^2.10.1",
         "eslint-plugin-prettier": "^5.5.5",
         "husky": "^9.1.7",
-        "lint-staged": "^16.2.7",
+        "lint-staged": "^16.4.0",
         "prettier": "^3.8.1",
         "rimraf": "^6.1.3",
         "tslib": "^2.8.1",
         "typescript": "5.9.3",
         "winston": "^3.19.0"
       },
+      "bin": {
+        "anaconda-pw-setup": "scripts/setup.js",
+        "playwright-utils-check-code-quality": "scripts/check-code-quality.sh"
+      },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@playwright/test": ">=1.58.2"
+        "@playwright/test": "^1.58.2"
       }
     },
     "node_modules/@anaconda/playwright-utils/node_modules/ansi-styles": {
@@ -296,17 +300,17 @@
       "license": "MIT"
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.84.0.tgz",
-      "integrity": "sha512-0xew1CxOam0gV5OMjh2KjFQZsKL2bByX1+q4j3E73MpYIdyUxcZb/xQct9ccUb+ve5KGUYbCUxyPnYB7RbuP+w==",
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.86.0.tgz",
+      "integrity": "sha512-ukZmRQ81WiTpDWO6D/cTBM7XbrNtutHKvAVnZN/8pldAwLoJArGOvkNyxPTBGsPjsoaQBJxlH+tE2TNA/92Qgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.8",
-        "@typescript-eslint/types": "^8.54.0",
-        "comment-parser": "1.4.5",
+        "@typescript-eslint/types": "^8.58.0",
+        "comment-parser": "1.4.6",
         "esquery": "^1.7.0",
-        "jsdoc-type-pratt-parser": "~7.1.1"
+        "jsdoc-type-pratt-parser": "~7.2.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -700,20 +704,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.1.tgz",
-      "integrity": "sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
+      "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.57.1",
-        "@typescript-eslint/type-utils": "8.57.1",
-        "@typescript-eslint/utils": "8.57.1",
-        "@typescript-eslint/visitor-keys": "8.57.1",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/type-utils": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -723,22 +727,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.57.1",
+        "@typescript-eslint/parser": "^8.58.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.1.tgz",
-      "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
+      "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.57.1",
-        "@typescript-eslint/types": "8.57.1",
-        "@typescript-eslint/typescript-estree": "8.57.1",
-        "@typescript-eslint/visitor-keys": "8.57.1",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -750,18 +754,18 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.1.tgz",
-      "integrity": "sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
+      "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.57.1",
-        "@typescript-eslint/types": "^8.57.1",
+        "@typescript-eslint/tsconfig-utils": "^8.58.1",
+        "@typescript-eslint/types": "^8.58.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -772,18 +776,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.1.tgz",
-      "integrity": "sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
+      "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.1",
-        "@typescript-eslint/visitor-keys": "8.57.1"
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -794,9 +798,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.1.tgz",
-      "integrity": "sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
+      "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -807,21 +811,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.1.tgz",
-      "integrity": "sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
+      "integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.1",
-        "@typescript-eslint/typescript-estree": "8.57.1",
-        "@typescript-eslint/utils": "8.57.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
         "debug": "^4.4.3",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -832,13 +836,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.1.tgz",
-      "integrity": "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
+      "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -850,21 +854,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.1.tgz",
-      "integrity": "sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
+      "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.57.1",
-        "@typescript-eslint/tsconfig-utils": "8.57.1",
-        "@typescript-eslint/types": "8.57.1",
-        "@typescript-eslint/visitor-keys": "8.57.1",
+        "@typescript-eslint/project-service": "8.58.1",
+        "@typescript-eslint/tsconfig-utils": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -874,20 +878,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.1.tgz",
-      "integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
+      "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.57.1",
-        "@typescript-eslint/types": "8.57.1",
-        "@typescript-eslint/typescript-estree": "8.57.1"
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -898,17 +902,17 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.1.tgz",
-      "integrity": "sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
+      "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/types": "8.58.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1702,9 +1706,9 @@
       }
     },
     "node_modules/comment-parser": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.5.tgz",
-      "integrity": "sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.6.tgz",
+      "integrity": "sha512-ObxuY6vnbWTN6Od72xfwN9DbzC7Y2vv8u1Soi9ahRKL37gb6y1qk6/dgjs+3JWuXJHWvsg3BXIwzd/rkmAwavg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2369,19 +2373,19 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "62.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.8.0.tgz",
-      "integrity": "sha512-hu3r9/6JBmPG6wTcqtYzgZAnjEG2eqRUATfkFscokESg1VDxZM21ZaMire0KjeMwfj+SXvgB4Rvh5LBuesj92w==",
+      "version": "62.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.9.0.tgz",
+      "integrity": "sha512-PY7/X4jrVgoIDncUmITlUqK546Ltmx/Pd4Hdsu4CvSjryQZJI2mEV4vrdMufyTetMiZ5taNSqvK//BTgVUlNkA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.84.0",
+        "@es-joy/jsdoccomment": "~0.86.0",
         "@es-joy/resolve.exports": "1.2.0",
         "are-docs-informative": "^0.0.2",
-        "comment-parser": "1.4.5",
+        "comment-parser": "1.4.6",
         "debug": "^4.4.3",
         "escape-string-regexp": "^4.0.0",
-        "espree": "^11.1.0",
+        "espree": "^11.2.0",
         "esquery": "^1.7.0",
         "html-entities": "^2.6.0",
         "object-deep-merge": "^2.0.0",
@@ -2429,9 +2433,9 @@
       }
     },
     "node_modules/eslint-plugin-playwright": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.10.0.tgz",
-      "integrity": "sha512-PByRBp5LhCUd3pd2dxQ7vq6p9iJRPCYgIDakYYkCAPJUPUuKA8/NxyFZVLf0FYYc7s4c+85BqLk+f8LeO0g6aw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.10.1.tgz",
+      "integrity": "sha512-qea3UxBOb8fTwJ77FMApZKvRye5DOluDHcev0LDJwID3RELeun0JlqzrNIXAB/SXCyB/AesCW/6sZfcT9q3Edg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2445,9 +2449,9 @@
       }
     },
     "node_modules/eslint-plugin-playwright/node_modules/globals": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
-      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
+      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3690,9 +3694,9 @@
       }
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.1.1.tgz",
-      "integrity": "sha512-/2uqY7x6bsrpi3i9LVU6J89352C0rpMk0as8trXxCtvd4kPk1ke/Eyif6wqfSLvoNJqcDG9Vk4UsXgygzCt2xA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
+      "integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5320,9 +5324,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cli"
   ],
   "devDependencies": {
-    "@anaconda/playwright-utils": "1.2.4",
+    "@anaconda/playwright-utils": "1.3.6",
     "@playwright/test": "^1.49.0",
     "cross-env": "^7.0.3",
     "dotenv": "^16.4.5",

--- a/tests/e2e/fixtures/fixture.ts
+++ b/tests/e2e/fixtures/fixture.ts
@@ -4,7 +4,7 @@ import { AnacondaAiCli } from '@pages/cli/anaconda-ai-cmds';
 export const test = baseTest.extend<{
   anacondaAiCli: AnacondaAiCli;
 }>({
-  anacondaAiCli: async ({ }, use) => {
+  anacondaAiCli: async ({}, use) => {
     await use(new AnacondaAiCli());
   },
 });

--- a/tests/e2e/pages/cli/anaconda-ai-cmds.ts
+++ b/tests/e2e/pages/cli/anaconda-ai-cmds.ts
@@ -1,4 +1,4 @@
-import { shellCommand, stripAnsiSgrAndTrim, verifyShellExitCode, type ShellResult } from 'tests/utils/CliUtils';
+import { type ShellResult, shellCommand, stripAnsiSgrAndTrim, verifyShellExitCode } from 'tests/utils/CliUtils';
 import * as cliCommands from './cliCommands';
 import { expect } from 'tests/test-setup/page-setup';
 import { INVALID_MODEL_ERROR_MESSAGE, ModelApi, ServerApi } from '@testdata/model-api';
@@ -26,10 +26,7 @@ export class AnacondaAiCli {
     verifyShellExitCode(result, 'anaconda ai models --json');
 
     const models = JSON.parse(stripAnsiSgrAndTrim(result.output)) as ModelApi[];
-    expect(
-      Array.isArray(models) && models.length,
-      'models output should be a non-empty array',
-    ).toBeGreaterThan(0);
+    expect(Array.isArray(models) && models.length, 'models output should be a non-empty array').toBeGreaterThan(0);
     this.assertModelResponseData(models);
   }
 
@@ -59,7 +56,7 @@ export class AnacondaAiCli {
 
     const servers = JSON.parse(stripAnsiSgrAndTrim(result.output)) as ServerApi[];
     const expectedModelFile = `${modelName}_${modelQuantization}.gguf`;
-    const server = servers.find((s) => s.model === expectedModelFile);
+    const server = servers.find(s => s.model === expectedModelFile);
 
     expect(server, `Expected server for model "${expectedModelFile}" to appear in servers list`).toBeDefined();
     expect(server!.server_id, `Expected server_id to contain model name "${modelName}"`).toContain(modelName);
@@ -90,10 +87,9 @@ export class AnacondaAiCli {
   }
 
   public verifyInvalidDownloadModelCommand(result: ShellResult): void {
-    expect(
-      result.exitCode,
-      `Expected invalid download command to fail, but got exit code ${result.exitCode}`,
-    ).not.toBe(0);
+    expect(result.exitCode, `Expected invalid download command to fail, but got exit code ${result.exitCode}`).not.toBe(
+      0,
+    );
     const output = stripAnsiSgrAndTrim(result.output).toLowerCase();
     expect(output, 'Expected the model to be invalid').toContain('error');
     expect(output, 'Expected output should contain invalid model error message').toContain(INVALID_MODEL_ERROR_MESSAGE);
@@ -122,10 +118,7 @@ export class AnacondaAiCli {
     const output = stripAnsiSgrAndTrim(result.output).toLowerCase();
     const expectedModelFile = `${modelName}_${modelQuantization}.gguf`.toLowerCase();
     expect(output.includes('running'), 'Expected status to be "running"').toBeTruthy();
-    expect(
-      output.includes('inference/serve/'),
-      'Expected "inference/serve/" is running',
-    ).toBeTruthy();
+    expect(output.includes('inference/serve/'), 'Expected "inference/serve/" is running').toBeTruthy();
     expect(
       output.includes(expectedModelFile),
       `Expected model "${expectedModelFile}" to appear in output`,
@@ -202,11 +195,34 @@ export class AnacondaAiCli {
       expect(model.trained_for, `models[${modelIndex}].trained_for should be defined`).toBeDefined();
 
       model.quantizations.forEach((quant, quantIndex) => {
-        expect(quant.method, `models[${modelIndex}].quantizations[${quantIndex}].method should be defined`).toBeDefined();
-        expect(quant.running, `models[${modelIndex}].quantizations[${quantIndex}].running should be defined`).not.toBeUndefined();
-        expect(quant.downloaded, `models[${modelIndex}].quantizations[${quantIndex}].downloaded should be defined`).not.toBeUndefined();
-        expect(quant.blocked, `models[${modelIndex}].quantizations[${quantIndex}].blocked should be defined`).not.toBeUndefined();
+        expect(
+          quant.method,
+          `models[${modelIndex}].quantizations[${quantIndex}].method should be defined`,
+        ).toBeDefined();
+        expect(
+          quant.running,
+          `models[${modelIndex}].quantizations[${quantIndex}].running should be defined`,
+        ).toBeDefined();
+        expect(
+          quant.downloaded,
+          `models[${modelIndex}].quantizations[${quantIndex}].downloaded should be defined`,
+        ).toBeDefined();
+        expect(
+          quant.blocked,
+          `models[${modelIndex}].quantizations[${quantIndex}].blocked should be defined`,
+        ).toBeDefined();
       });
     });
+  }
+
+  public async runAnacondaAiVersionCommand(): Promise<ShellResult> {
+    return await shellCommand(cliCommands.anacondaAiVersionCmd);
+  }
+
+  public verifyAnacondaAiVersionCommand(result: ShellResult): void {
+    verifyShellExitCode(result, 'anaconda ai --version');
+
+    const output = stripAnsiSgrAndTrim(result.output).toLowerCase();
+    expect(output.includes('anaconda-ai'), 'Expected "anaconda-ai" to be in output').toBeTruthy();
   }
 }

--- a/tests/e2e/pages/cli/anaconda-ai-setup.ts
+++ b/tests/e2e/pages/cli/anaconda-ai-setup.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { shellCommand, verifyShellExitCode, type ShellResult } from 'tests/utils/CliUtils';
+import { type ShellResult, shellCommand, verifyShellExitCode } from 'tests/utils/CliUtils';
 
 import * as cliCommands from './cliCommands';
 
@@ -12,8 +12,7 @@ export class AnacondaAiSetupCli {
   public verifyInstallAiPackageCommand(result: ShellResult): void {
     verifyShellExitCode(result, 'install command');
     const output = result.output.toLowerCase();
-    const isInstalledNow =
-      output.includes('executing transaction') && output.includes('anaconda-ai');
+    const isInstalledNow = output.includes('executing transaction') && output.includes('anaconda-ai');
     const isAlreadyInstalled = output.includes('all requested packages already installed');
 
     expect(
@@ -38,7 +37,7 @@ export class AnacondaAiSetupCli {
     verifyShellExitCode(result, 'sites list command');
   }
 
-  // True if `anaconda sites list` output contains the given site name. 
+  // True if `anaconda sites list` output contains the given site name.
   public isSiteNameListed(listResult: ShellResult, name: string): boolean {
     const output = `${listResult.output}\n${listResult.stderrOutput}`;
     return output.includes(`│ ${name} `);

--- a/tests/e2e/pages/cli/cliCommands.ts
+++ b/tests/e2e/pages/cli/cliCommands.ts
@@ -4,11 +4,9 @@ const anacondaAiChannel = process.env.ANACONDA_AI_CHANNEL ?? 'anaconda-cloud/lab
 const anacondaAiVersion = process.env.ANACONDA_AI_VERSION ?? '0.5.0';
 
 // Run all command in the anaconda-cli environment
-const condaRun = (inner: string): string =>
-  `conda run -n anaconda-cli --no-capture-output ${inner}`;
+const condaRun = (inner: string): string => `conda run -n anaconda-cli --no-capture-output ${inner}`;
 
-export const installAiPackageCmd =
-  `conda create -c defaults -c conda-forge ${anacondaAiChannel}::anaconda-ai=${anacondaAiVersion} -n anaconda-cli --yes`;
+export const installAiPackageCmd = `conda create -c defaults -c conda-forge ${anacondaAiChannel}::anaconda-ai=${anacondaAiVersion} -n anaconda-cli --yes`;
 
 // Verify the Anaconda AI package environment is runnable
 export const activateAiPackageEnvCmd = condaRun('conda list anaconda-ai');
@@ -21,20 +19,19 @@ export const addSiteCmd = (domain: string, name: string): string =>
 export const modifySiteCmd = (domain: string, name: string): string =>
   condaRun(`anaconda sites modify --domain ${domain} --name ${name} --default --yes`);
 
-export const configureAiPackageEnvToUseSandboxCmd = condaRun(
-  'anaconda ai config --backend ai-catalyst --yes',
-);
+export const configureAiPackageEnvToUseSandboxCmd = condaRun('anaconda ai config --backend ai-catalyst --yes');
 
 export const authWhoamiCmd = condaRun('anaconda auth whoami');
 
 export const anacondaAiHelpCmd = condaRun('anaconda ai --help');
 
+// Anaconda AI Version Command
+export const anacondaAiVersionCmd = condaRun('anaconda ai version --json');
+
 // Anaconda AI Models Command
 export const anacondaAiModelsListCmd = condaRun('anaconda ai models --json');
 
-export const anacondaAiBlockedModelsListCmd = condaRun(
-  'anaconda ai models --show-blocked --json',
-);
+export const anacondaAiBlockedModelsListCmd = condaRun('anaconda ai models --show-blocked --json');
 
 // Download Model Command
 export const downloadModelCmd = (modelName: string, modelQuantization: string): string =>

--- a/tests/e2e/specs/cli/anaconda-ai.spec.ts
+++ b/tests/e2e/specs/cli/anaconda-ai.spec.ts
@@ -7,6 +7,11 @@ import {
 } from '@testdata/model-api';
 
 test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
+  test('anaconda ai version command', async ({ anacondaAiCli }) => {
+    const result = await anacondaAiCli.runAnacondaAiVersionCommand();
+    anacondaAiCli.verifyAnacondaAiVersionCommand(result);
+  });
+
   test('anaconda ai --help', async ({ anacondaAiCli }) => {
     const result = await anacondaAiCli.runAnacondaAiHelpCommand();
     anacondaAiCli.verifyAnacondaAiHelpCommand(result);
@@ -31,10 +36,7 @@ test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
   });
 
   test('anaconda ai download invalid model command', async ({ anacondaAiCli }) => {
-    const result = await anacondaAiCli.runDownloadModelCommand(
-      INVALID_MODEL_NAME,
-      INVALID_MODEL_QUANTIZATION,
-    );
+    const result = await anacondaAiCli.runDownloadModelCommand(INVALID_MODEL_NAME, INVALID_MODEL_QUANTIZATION);
     anacondaAiCli.verifyInvalidDownloadModelCommand(result);
   });
 
@@ -44,7 +46,7 @@ test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
   });
 
   test('anaconda ai server lifecycle: launch, verify, stop, and delete a model server', async ({ anacondaAiCli }) => {
-    await test.step('step 1: launch model server and verify it is running', async () => {
+    await test.step('1: launch model server and verify it is running', async () => {
       const launchResult = await anacondaAiCli.runLaunchModelCommand(
         DOWNLOAD_TEST_MODEL_NAME,
         DOWNLOAD_TEST_MODEL_QUANTIZATION,
@@ -52,12 +54,16 @@ test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
       anacondaAiCli.verifyLaunchModelCommand(launchResult, DOWNLOAD_TEST_MODEL_NAME, DOWNLOAD_TEST_MODEL_QUANTIZATION);
     });
 
-    await test.step('step 2: verify server appears in servers list with status "running"', async () => {
+    await test.step('2: verify server appears in servers list with status "running"', async () => {
       const serversResult = await anacondaAiCli.runAnacondaAiServersListCommand();
-      anacondaAiCli.verifyRunningServerInList(serversResult, DOWNLOAD_TEST_MODEL_NAME, DOWNLOAD_TEST_MODEL_QUANTIZATION);
+      anacondaAiCli.verifyRunningServerInList(
+        serversResult,
+        DOWNLOAD_TEST_MODEL_NAME,
+        DOWNLOAD_TEST_MODEL_QUANTIZATION,
+      );
     });
 
-    await test.step('step 3: launching the same server again returns AnacondaAIException', async () => {
+    await test.step('3: launching the same server again returns AnacondaAIException', async () => {
       const duplicateResult = await anacondaAiCli.runLaunchModelCommand(
         DOWNLOAD_TEST_MODEL_NAME,
         DOWNLOAD_TEST_MODEL_QUANTIZATION,
@@ -65,7 +71,7 @@ test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
       anacondaAiCli.verifyDuplicateLaunchModelCommand(duplicateResult);
     });
 
-    await test.step('step 4: stop the model server and verify it is stopped', async () => {
+    await test.step('4: stop the model server and verify it is stopped', async () => {
       const stopResult = await anacondaAiCli.runStopModelCommand(
         DOWNLOAD_TEST_MODEL_NAME,
         DOWNLOAD_TEST_MODEL_QUANTIZATION,
@@ -73,28 +79,26 @@ test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
       anacondaAiCli.verifyStopModelCommand(stopResult, DOWNLOAD_TEST_MODEL_NAME, DOWNLOAD_TEST_MODEL_QUANTIZATION);
     });
 
-    await test.step('step 5: delete the model server and verify it is removed', async () => {
+    await test.step('5: delete the model server and verify it is removed', async () => {
       const deleteResult = await anacondaAiCli.runStopAndRemoveModelCommand(
         DOWNLOAD_TEST_MODEL_NAME,
         DOWNLOAD_TEST_MODEL_QUANTIZATION,
       );
-      anacondaAiCli.verifyStopAndRemoveModelCommand(deleteResult, DOWNLOAD_TEST_MODEL_NAME, DOWNLOAD_TEST_MODEL_QUANTIZATION);
+      anacondaAiCli.verifyStopAndRemoveModelCommand(
+        deleteResult,
+        DOWNLOAD_TEST_MODEL_NAME,
+        DOWNLOAD_TEST_MODEL_QUANTIZATION,
+      );
     });
   });
 
   test('anaconda ai launch - invalid format returns ValueError', async ({ anacondaAiCli }) => {
-    const result = await anacondaAiCli.runLaunchModelCommand(
-      INVALID_MODEL_NAME,
-      INVALID_MODEL_QUANTIZATION,
-    );
+    const result = await anacondaAiCli.runLaunchModelCommand(INVALID_MODEL_NAME, INVALID_MODEL_QUANTIZATION);
     anacondaAiCli.verifyLaunchModelInvalidFormatCommand(result);
   });
 
   test('anaconda ai launch - unknown model returns ModelNotFound', async ({ anacondaAiCli }) => {
-    const result = await anacondaAiCli.runLaunchModelCommand(
-      INVALID_MODEL_NAME,
-      DOWNLOAD_TEST_MODEL_QUANTIZATION,
-    );
+    const result = await anacondaAiCli.runLaunchModelCommand(INVALID_MODEL_NAME, DOWNLOAD_TEST_MODEL_QUANTIZATION);
     anacondaAiCli.verifyLaunchModelNotFoundCommand(result);
   });
 });

--- a/tests/test-setup/global-setup.ts
+++ b/tests/test-setup/global-setup.ts
@@ -3,10 +3,12 @@
  * Runs the Anaconda AI package install before any tests.
  */
 import { AnacondaAiSetupCli } from '../e2e/pages/cli/anaconda-ai-setup';
-import { baseDomain, SELF_HOSTED_SITE_NAME } from '@testdata/site-data';
+import { SELF_HOSTED_SITE_NAME, baseDomain } from '@testdata/site-data';
 
 async function setupAnacondaAi(cli: AnacondaAiSetupCli): Promise<void> {
-  console.log(`[Global Setup] Installing and verifying Anaconda AI in "anaconda-cli" (version: ${process.env.ANACONDA_AI_VERSION ?? 'not set'})`,);
+  console.log(
+    `[Global Setup] Installing and verifying Anaconda AI in "anaconda-cli" (version: ${process.env.ANACONDA_AI_VERSION ?? 'not set'})`,
+  );
 
   // Install the Anaconda AI package
   const installResult = await cli.runInstallAiPackageCommand();


### PR DESCRIPTION
This PR adds automation coverage for the Anaconda AI CLI version command and includes minor formatting and import cleanup across the CLI test files.

Changes
Added automated test for anaconda ai version --json
Added CLI command helper for version command
Added run and verify methods for version command in AnacondaAiCli
Updated version command to use:
anaconda ai version --json
Upgraded @anaconda/playwright-utils from 1.2.4 to 1.3.6
Applied small formatting and import-order cleanup in CLI-related files
Validation
Added test coverage for version command output
Existing CLI command tests remain aligned with current framework structure