### PR TITLE
test(e2e): add negative stop command coverage

### DIFF
--- a/tests/e2e/pages/cli/anaconda-ai-cmds.ts
+++ b/tests/e2e/pages/cli/anaconda-ai-cmds.ts
@@ -1,7 +1,7 @@
 import { type ShellResult, shellCommand, stripAnsiSgrAndTrim, verifyShellExitCode } from 'tests/utils/CliUtils';
 import * as cliCommands from './cliCommands';
 import { expect } from 'tests/test-setup/page-setup';
-import { INVALID_MODEL_ERROR_MESSAGE, ModelApi, ServerApi } from '@testdata/model-api';
+import { INVALID_MODEL_ERROR_MESSAGE, INVALID_SERVER_NAME, ModelApi, ServerApi } from '@testdata/model-api';
 
 // CLI helpers for Anaconda AI package CLI commands.
 export class AnacondaAiCli {
@@ -59,9 +59,10 @@ export class AnacondaAiCli {
     const server = servers.find(s => s.model === expectedModelFile);
 
     expect(server, `Expected server for model "${expectedModelFile}" to appear in servers list`).toBeDefined();
-    expect(server!.server_id, `Expected server_id to contain model name "${modelName}"`).toContain(modelName);
-    expect(server!.model, `Expected model to be "${expectedModelFile}"`).toBe(expectedModelFile);
-    expect(server!.status, `Expected server status to be "running"`).toBe('running');
+    const { server_id, model, status } = server as ServerApi;
+    expect(server_id, `Expected server_id to contain model name "${modelName}"`).toContain(modelName);
+    expect(model, `Expected model to be "${expectedModelFile}"`).toBe(expectedModelFile);
+    expect(status, `Expected server status to be "running"`).toBe('running');
   }
 
   // Executes `anaconda ai download <model>/<quant>` (positional; no --model)
@@ -160,6 +161,22 @@ export class AnacondaAiCli {
     expect(
       output.includes(expectedModelFile),
       `Expected model "${expectedModelFile}" to appear in output`,
+    ).toBeTruthy();
+  }
+
+  // Executes `anaconda ai stop <serverName>` with a non-existent server name
+  public async runStopModelNotFoundCommand(): Promise<ShellResult> {
+    return await shellCommand(cliCommands.stopModelNotFoundCmd(INVALID_SERVER_NAME));
+  }
+
+  // Validates that stopping a non-existent server exits non-zero with a ServerNotFoundError
+  public verifyStopModelNotFoundCommand(result: ShellResult): void {
+    expect(result.exitCode, 'Expected non-zero exit code for unknown server').not.toBe(0);
+
+    const output = stripAnsiSgrAndTrim(result.output).toLowerCase();
+    expect(
+      output.includes('servernotfounderror') || output.includes('was not found'),
+      'Expected ServerNotFoundError for unknown server',
     ).toBeTruthy();
   }
 

--- a/tests/e2e/pages/cli/cliCommands.ts
+++ b/tests/e2e/pages/cli/cliCommands.ts
@@ -51,3 +51,7 @@ export const stopModelCmd = (modelName: string, modelQuantization: string): stri
 // Stop and remove server — same as stop but with --rm to delete it
 export const stopAndRemoveModelCmd = (modelName: string, modelQuantization: string): string =>
   condaRun(`anaconda ai stop ${modelName}_${modelQuantization}.gguf --rm`);
+
+// Negative: stop a server that does not exist — triggers ServerNotFoundError
+export const stopModelNotFoundCmd = (serverName: string): string =>
+  condaRun(`anaconda ai stop ${serverName}`);

--- a/tests/e2e/specs/cli/anaconda-ai.spec.ts
+++ b/tests/e2e/specs/cli/anaconda-ai.spec.ts
@@ -101,4 +101,9 @@ test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
     const result = await anacondaAiCli.runLaunchModelCommand(INVALID_MODEL_NAME, DOWNLOAD_TEST_MODEL_QUANTIZATION);
     anacondaAiCli.verifyLaunchModelNotFoundCommand(result);
   });
+
+  test('anaconda ai stop - unknown server returns ServerNotFoundError', async ({ anacondaAiCli }) => {
+    const result = await anacondaAiCli.runStopModelNotFoundCommand();
+    anacondaAiCli.verifyStopModelNotFoundCommand(result);
+  });
 });

--- a/tests/e2e/testdata/model-api.ts
+++ b/tests/e2e/testdata/model-api.ts
@@ -29,3 +29,6 @@ export const DOWNLOAD_TEST_MODEL_QUANTIZATION = 'q4_k_m';
 export const INVALID_MODEL_NAME = 'invalid-model';
 export const INVALID_MODEL_QUANTIZATION = 'invalid-quantization';
 export const INVALID_MODEL_ERROR_MESSAGE = 'you must include the quantization method in the model';
+
+// Invalid server name for negative stop tests
+export const INVALID_SERVER_NAME = 'invalid-server';


### PR DESCRIPTION
## Ticket
[AIC-3046](https://anaconda.atlassian.net/browse/AIC-3046)

### Summary

- Adds a negative test for anaconda ai stop with a non-existent server name, verifying that ServerNotFoundError is returned with a non-zero exit code
- Adds ServerApi type, INVALID_SERVER_NAME, and stopModelNotFoundCmd to support the new test
- Adds runStopModelNotFoundCommand / verifyStopModelNotFoundCommand page methods following the existing pattern


[AIC-3046]: https://anaconda.atlassian.net/browse/AIC-3046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ