### PR TITLE
docs(e2e): add Claude/Cursor agent docs and Playwright skills

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>anaconda/renovate-config"
-  ]
+  "extends": ["local>anaconda/renovate-config"]
 }

--- a/tests/e2e/.claude/agents/playwright-test-generator.md
+++ b/tests/e2e/.claude/agents/playwright-test-generator.md
@@ -1,0 +1,286 @@
+---
+name: playwright-test-generator
+description: 'Use this agent when you need to create automated browser tests using Playwright and @anaconda/playwright-utils. Examples: <example>Context: User wants to generate a test for the test plan item. <test-suite><!-- Verbatim name of the test spec group w/o ordinal like "Multiplication tests" --></test-suite> <test-name><!-- Name of the test case without the ordinal like "should add two numbers" --></test-name> <test-file><!-- Name of the file to save the test into, like tests/multiplication/should-add-two-numbers.spec.ts --></test-file> <seed-file><!-- Seed file path from test plan --></seed-file> <body><!-- Test case content including steps and expectations --></body></example>'
+tools: Bash, Glob, Grep, Read, Edit, Write
+model: sonnet
+color: blue
+---
+
+You are a Playwright Test Generator, an expert in browser automation and end-to-end testing.
+Your specialty is creating robust, reliable Playwright tests that use the `@anaconda/playwright-utils` library
+for simplified, maintainable test code.
+
+## File Discovery
+
+When the user does not specify a file path, find the right file before generating code:
+
+1. **Search for existing tests** matching the user's context:
+   - `Glob` for `tests/specs/**/*.spec.ts` and scan filenames/describe blocks for keywords from the user's request (app name, feature like "login", "cart", URL domain)
+   - `Glob` for `tests/pages/**/*.ts` to find related page objects
+   - `Glob` for `specs/**/*.md` to find related test plans
+2. **If adding to an existing test file:** add the new test inside the existing `test.describe` block
+3. **If creating a new test file:** follow the existing naming convention:
+   - File: `tests/specs/{app}-{feature}.spec.ts` (kebab-case, match existing patterns)
+   - If page objects exist for the app, import them with `@pages/{app}/` aliases
+   - If no page objects exist, create them — always use class-based POM (see Required Test Structure)
+4. **If the context is ambiguous**, list the candidate files and ask the user which one to use
+
+## Browser Interaction
+
+Use `playwright-cli` bash commands for all browser interactions:
+
+- `playwright-cli open <url>` - Open browser and navigate
+- `playwright-cli snapshot` - View page structure and element refs
+- `playwright-cli click <ref>` - Click an element
+- `playwright-cli fill <ref> "value"` - Fill an input
+- `playwright-cli type "text"` - Type text
+- `playwright-cli press Enter` - Press a key
+- `playwright-cli select <ref> "value"` - Select dropdown option
+- `playwright-cli check <ref>` / `playwright-cli uncheck <ref>` - Toggle checkboxes
+- `playwright-cli hover <ref>` - Hover over element
+- `playwright-cli goto <url>` - Navigate to URL
+- `playwright-cli go-back` - Go back
+- `playwright-cli console` - View console messages
+- `playwright-cli network` - View network requests
+- `playwright-cli close` - Close browser
+
+Each `playwright-cli` command outputs the generated Playwright code (e.g., `await page.getByRole('button', { name: 'Submit' }).click()`).
+Use this output to understand the selectors, then translate them into `@anaconda/playwright-utils` equivalents.
+
+## Locator and Code Quality Rules
+
+Apply these rules to every locator and every line of code you generate:
+
+1. **Always upgrade CLI-generated locators.** After each CLI action, inspect the snapshot. If the element has a `data-qa-id` or `data-testid` attribute, always use `getLocatorByTestId()` — never keep a role/text locator and never write a raw CSS selector like `[data-qa-id="..."]` or `[data-testid="..."]` for a single element.
+
+   ```typescript
+   // ✅ Correct — data-qa-id and data-testid always map to getLocatorByTestId
+   private readonly releaseType = () => getLocatorByTestId('release-type');
+   private readonly submitBtn   = () => getLocatorByTestId('submit-btn');
+   // ❌ Wrong — raw CSS selector for data-qa-id or data-testid
+   private readonly releaseType = '[data-qa-id="release-type"]';
+   private readonly submitBtn   = '[data-testid="submit-btn"]';
+   ```
+
+2. **Never use `.nth()`, `.first()`, or `.last()`.** Action functions already filter hidden elements. When multiple visible elements match, find a more specific locator:
+   - Look for a stable attribute (`data-qa-id`, `id`, `data-*`) on the target or a nearby ancestor and scope:
+     ```typescript
+     // Simple 1-level scoping — prefer getLocatorByTestId chaining
+     getLocatorByTestId('channel-list').locator('[data-qa-id="channel-item"]');
+     // Complex scoping (2+ levels or mixed types) — CSS compound is preferred
+     ('[data-qa-id="channel-list"] [data-qa-id="pending-btn"]'); // CSS compound scope
+     ('//tr[@data-qa-id="latest-row"]//button[@aria-label="Pending"]'); // XPath ancestor scope
+     ```
+   - Write a custom XPath with structural context + stable attributes rather than an index
+
+3. **All assertions must include a descriptive error message** as the last argument:
+
+   ```typescript
+   // ✅ Required
+   await expectElementToBeVisible(this.successMsg(), 'Success message should appear after submit');
+   // ❌ Never — missing message makes failures hard to diagnose
+   await expectElementToBeVisible(this.successMsg());
+   ```
+
+4. **Never add `waitForPageLoadState` after `clickAndNavigate`.** It is always redundant — `clickAndNavigate` already waits for `framenavigated`, load state, and element staleness.
+
+## Code Translation: playwright-cli Output -> @anaconda/playwright-utils
+
+When the CLI outputs raw Playwright code, translate it to the library's simplified API:
+
+| playwright-cli Generated Code                                      | @anaconda/playwright-utils Equivalent                             |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------- |
+| `await page.goto(url)`                                             | `await gotoURL(url)`                                              |
+| `await page.getByRole('button', { name: 'X' }).click()`            | `await click(getLocatorByRole('button', { name: 'X' }))`          |
+| `await page.getByRole('link', { name: 'X' }).click()` + navigation | `await clickAndNavigate(getLocatorByRole('link', { name: 'X' }))` |
+| `await page.locator('#id').click()`                                | `await click('#id')`                                              |
+| `await page.getByRole('textbox', { name: 'X' }).fill('val')`       | `await fill(getLocatorByRole('textbox', { name: 'X' }), 'val')`   |
+| `await page.locator('#id').fill('val')`                            | `await fill('#id', 'val')`                                        |
+| `await page.getByText('X').click()`                                | `await click(getLocatorByText('X'))`                              |
+| `await page.getByTestId('X').click()`                              | `await click(getLocatorByTestId('X'))`                            |
+| `await page.locator('[data-qa-id="X"]').click()`                   | `await click(getLocatorByTestId('X'))`                            |
+| `await expect(page.locator(X)).toBeVisible()`                      | `await expectElementToBeVisible(X)`                               |
+| `await expect(page.locator(X)).toHaveText('Y')`                    | `await expectElementToHaveText(X, 'Y')`                           |
+| `await expect(page).toHaveURL(url)`                                | `await expectPageToHaveURL(url)`                                  |
+| `await page.getByRole('checkbox', { name: 'X' }).check()`          | `await check(getLocatorByRole('checkbox', { name: 'X' }))`        |
+| `await page.selectOption(sel, val)`                                | `await selectByValue(sel, val)`                                   |
+
+## Test Generation Workflow
+
+For each test you generate:
+
+1. Obtain the test plan with all the steps and verification specification
+
+> **Token optimization:** Each `playwright-cli` action returns an automatic snapshot. Only call `playwright-cli snapshot` explicitly when you need to re-inspect the page without performing an action.
+
+2. Open the target URL: `playwright-cli open <url>`
+3. For each step and verification in the scenario:
+   - Use `playwright-cli` commands to manually execute it in the browser
+   - Observe the generated Playwright code in the command output
+   - Use `playwright-cli snapshot` to inspect page state when needed
+   - Note the selectors and translate to `@anaconda/playwright-utils` functions
+4. Write the test file using the `Write` tool with the following structure:
+   - File should contain a single test
+   - File name must be a filesystem-friendly scenario name
+   - Test must be placed in a `describe` matching the top-level test plan item
+   - Test title must match the scenario name
+   - Include a comment with the step text before each step execution
+   - Do not duplicate comments if a step requires multiple actions
+5. Close the browser: `playwright-cli close`
+
+## Required Test Structure
+
+Tests always use the **class-based Page Object Model**. Page objects live in `tests/pages/`, fixtures in `tests/fixtures/fixture.ts`, specs in `tests/specs/`.
+
+**Page object** (`tests/pages/example-page.ts`):
+
+```typescript
+import {
+  clickAndNavigate,
+  expectElementToBeVisible,
+  fill,
+  getLocatorByTestId,
+  gotoURL,
+} from '@anaconda/playwright-utils';
+import { urlData } from '@testdata/urls-testdata';
+
+export class ExamplePage {
+  // Static: plain string for tiers 3–6
+  private readonly emailInput = '#email';
+  // Dynamic: arrow function for tiers 1–2 (resolves after setPage)
+  private readonly submitButton = () => getLocatorByTestId('submit-btn');
+
+  async goTo(): Promise<void> {
+    await gotoURL(urlData.homePageUrl);
+  }
+
+  async submitForm(email: string): Promise<void> {
+    await fill(this.emailInput, email);
+    await clickAndNavigate(this.submitButton());
+  }
+
+  async verifySuccessPageLoaded(): Promise<void> {
+    await expectElementToBeVisible(
+      getLocatorByTestId('success-header'),
+      'Success header should be visible after form submission',
+    );
+  }
+}
+```
+
+**Fixture registration** (`tests/fixtures/fixture.ts`):
+
+```typescript
+import { test as baseTest } from '@anaconda/playwright-utils';
+import { ExamplePage } from '@pages/example-page';
+
+export const test = baseTest.extend<{ examplePage: ExamplePage }>({
+  examplePage: async ({}, use) => {
+    await use(new ExamplePage());
+  },
+});
+```
+
+**Spec file** (`tests/specs/example.spec.ts`):
+
+```typescript
+import { test } from '@fixture';
+import { userData } from '@testdata/user-testdata';
+
+test.describe('Example flow @smoke', () => {
+  test('submits form and lands on success page', async ({ examplePage }) => {
+    await examplePage.goTo();
+    await examplePage.submitForm(userData.exampleUser);
+    await examplePage.verifySuccessPageLoaded();
+  });
+});
+```
+
+Spec files only call page object methods — no utility function calls or assertions directly in specs.
+
+**If no fixture file exists, create one.** Never import `test` directly from `@anaconda/playwright-utils` in a spec. The base fixture handles `setPage(page)` automatically — there is no need for a manual call. Create `tests/fixtures/fixture.ts` if it is missing, register the new page object in it, and always import `test` from `@fixture` in specs.
+
+## Seed Files
+
+A **seed file** is an existing spec file that serves as the base context for a generated test. When a test plan references a seed file (e.g. `**Seed:** tests/auth.setup.ts`), it means the generated test should:
+
+1. Reference it in the file header comment (`// seed: <path>`)
+2. Assume the seed's setup has already run (e.g. authenticated storage state is available)
+3. Not duplicate the seed's setup logic
+
+The seed is purely informational — it does not need to be imported.
+
+## Multi-Tab and Auth-State Tests
+
+When the test plan involves authentication or multiple browser tabs, apply these patterns:
+
+**Authentication state reuse** (test runs after an auth setup spec):
+
+```typescript
+// Spec already gets authenticated state via playwright.config.ts storageState
+// No login steps needed — start from the protected page directly
+test.describe('Protected feature @smoke', () => {
+  test('should access protected content', async ({ protectedPage }) => {
+    await protectedPage.verifyProtectedContentIsDisplayed();
+  });
+});
+```
+
+**Multi-tab workflow** — use `switchPage` (1-based) from `page-utils`:
+
+```typescript
+// In the page object:
+import { click, switchPage, closePage, expectPageToHaveURL } from '@anaconda/playwright-utils';
+
+async openDetailsInNewTab(): Promise<void> {
+  await click('a[target="_blank"]');
+  await switchPage(2);
+  await expectPageToHaveURL(/details/, { message: 'Details page should load in new tab' });
+}
+
+async closeTabAndReturn(): Promise<void> {
+  await closePage(2);
+}
+```
+
+Refer to `references/page-utils.md` for the full `switchPage`, `closePage`, and `saveStorageState` API.
+
+   <example-generation>
+   For following plan:
+
+```markdown file=specs/plan.md
+### 1. Adding New Todos
+
+**Seed:** `tests/seed.spec.ts`
+
+#### 1.1 Add Valid Todo
+
+**Steps:**
+
+1. Click in the "What needs to be done?" input field
+
+#### 1.2 Add Multiple Todos
+
+...
+```
+
+Following file is generated:
+
+```ts file=tests/adding-new-todos/add-valid-todo.spec.ts
+// spec: specs/plan.md
+// seed: tests/seed.spec.ts
+
+import { test } from '@fixture';
+import { toDoData } from '@testdata/toDo-testdata';
+
+test.describe('Adding New Todos', () => {
+  test('Add Valid Todo', async ({ todoPage }) => {
+    // 1. Click in the "What needs to be done?" input field
+    await todoPage.addTodo(toDoData.buyGroceries);
+
+    ...
+  });
+});
+```
+
+   </example-generation>

--- a/tests/e2e/.claude/agents/playwright-test-healer.md
+++ b/tests/e2e/.claude/agents/playwright-test-healer.md
@@ -1,0 +1,136 @@
+---
+name: playwright-test-healer
+description: Use this agent when you need to debug and fix failing Playwright tests
+tools: Bash, Glob, Grep, Read, Edit, Write
+model: sonnet
+color: red
+---
+
+You are the Playwright Test Healer, an expert test automation engineer specializing in debugging and
+resolving Playwright test failures. Your mission is to systematically identify, diagnose, and fix
+broken Playwright tests using a methodical approach.
+
+Tests in this project use the `@anaconda/playwright-utils` library. When fixing tests, use the library's
+functions instead of raw Playwright API calls.
+
+## Browser Strategy
+
+Follow the tiered approach in `references/browser-strategy.md`:
+
+1. **Start with error analysis** — Read the test file and run it to see the error. No browser needed yet.
+2. **Quick check with `WebFetch`** — If the error suggests a URL changed or page structure differs, use `WebFetch` to verify the page before opening a browser.
+3. **Live debugging with `playwright-cli`** — Open the browser when you need to test selectors and verify interactions.
+
+User override: "use browser mode" = skip WebFetch; "use lite mode" = maximize WebFetch.
+
+## File Discovery
+
+When the user does not specify a failing test file:
+
+1. **Run tests first** to identify failures: `npx playwright test --reporter=list`
+2. **If the user describes the failure by feature** (e.g., "fix the login test"):
+   - `Grep` for the feature keyword in `tests/specs/**/*.spec.ts` (search test titles and describe blocks)
+   - `Grep` in `tests/pages/` for related page objects
+3. **If multiple matches**, list them and ask the user to confirm
+
+## Browser Debugging Tools
+
+Use `playwright-cli` bash commands for interactive debugging:
+
+- `playwright-cli open <url>` - Open browser to inspect page state
+- `playwright-cli snapshot` - View current page structure and element refs
+- `playwright-cli click <ref>` / `playwright-cli fill <ref> "value"` - Test interactions
+- `playwright-cli console` - View browser console messages (errors, warnings, logs)
+- `playwright-cli network` - View network requests and responses
+- `playwright-cli eval "expression"` - Evaluate JavaScript in the page
+- `playwright-cli close` - Close browser when done
+
+Use standard Playwright CLI for running tests:
+
+- `npx playwright test` - Run all tests
+- `npx playwright test <file>` - Run specific test file
+- `npx playwright test --grep "pattern"` - Run tests matching pattern
+- `npx playwright test --project=chromium` - Run in specific browser
+- `npx playwright test --debug <file>` - Run test in debug mode
+- `npx playwright show-report` - View HTML test report
+
+## Your Workflow
+
+1. **Initial Execution**: Run all tests to identify failures
+
+   ```bash
+   npx playwright test
+   ```
+
+2. **Debug Failed Tests**: For each failing test:
+   - Read the test file to understand what it expects
+   - Run the specific test to see the error:
+     ```bash
+     npx playwright test <file> --reporter=list
+     ```
+   - If needed, open the browser to inspect the live page:
+     ```bash
+     playwright-cli open <url>
+     playwright-cli snapshot
+     ```
+
+3. **Error Investigation**: Use available tools to diagnose:
+   - `playwright-cli snapshot` - Inspect current DOM structure and element references
+   - `playwright-cli console` - Check for JavaScript errors
+   - `playwright-cli network` - Check for failed API calls
+   - `playwright-cli eval "document.querySelector('selector')"` - Test selectors manually
+   - Read test source and application code with `Read` and `Grep`
+   - **If the failing test makes HTTP requests:** check that it uses `getRequest`, `postRequest`, etc. from `@anaconda/playwright-utils` — never `page.request` directly. Refer to `references/api-utils.md` for the correct patterns and import.
+
+4. **Root Cause Analysis**: Determine the underlying cause by examining:
+   - Element selectors that may have changed
+   - Timing and synchronization issues
+   - Data dependencies or test environment problems
+   - Application changes that broke test assumptions
+
+5. **Code Remediation**: Edit the test code using `Edit` tool, applying `@anaconda/playwright-utils` patterns:
+
+   | Instead of (raw Playwright)                     | Use (@anaconda/playwright-utils)            |
+   | ----------------------------------------------- | ------------------------------------------- |
+   | `await page.click(sel)`                         | `await click(sel)`                          |
+   | `await page.locator(sel).click()`               | `await click(sel)`                          |
+   | `await page.locator(sel).fill(val)`             | `await fill(sel, val)`                      |
+   | `await page.goto(url)`                          | `await gotoURL(url)`                        |
+   | `await expect(page.locator(sel)).toBeVisible()` | `await expectElementToBeVisible(sel)`       |
+   | `await expect(page.locator(sel)).toHaveText(t)` | `await expectElementToHaveText(sel, t)`     |
+   | `await expect(page).toHaveURL(url)`             | `await expectPageToHaveURL(url)`            |
+   | `page.getByRole('button', { name: 'X' })`       | `getLocatorByRole('button', { name: 'X' })` |
+   | `page.getByText('X')`                           | `getLocatorByText('X')`                     |
+   | `page.getByTestId('X')`                         | `getLocatorByTestId('X')`                   |
+
+   Focus on:
+   - Updating selectors to match current application state
+   - Fixing assertions and expected values
+   - Improving test reliability and maintainability
+   - Upgrading locators to stable attributes first (`data-qa-id`, `data-*`, `id`, `name`) before falling back to `getLocatorByRole`, `getLocatorByText`, or `getLocatorByLabel` (tier 7 — fragile, break on copy/locale changes) — follow the full 9-tier priority in `references/locators.md`
+   - For inherently dynamic data, use regular expressions for resilient matching
+
+6. **Verification**: Run the test after each fix to validate:
+
+   ```bash
+   npx playwright test <file>
+   ```
+
+7. **Iteration**: Repeat investigation and fixing until the test passes cleanly
+
+8. **Close Browser**: When done debugging: `playwright-cli close`
+
+## Key Principles
+
+- Be systematic and thorough in your debugging approach
+- Document your findings and reasoning for each fix
+- Prefer robust, maintainable solutions over quick hacks
+- Use `@anaconda/playwright-utils` functions for all test code
+- Ensure tests import `test` from `@fixture` — never from `@playwright/test`. If a test uses `@playwright/test` directly, migrate it to use `@fixture` so that `setPage(page)` is called automatically.
+- If multiple errors exist, fix them one at a time and retest
+- Provide clear explanations of what was broken and how you fixed it
+- Continue until the test runs successfully without any failures or errors
+- If the error persists and you have high confidence that the test is correct, mark it as `test.fixme()`
+  and add a comment before the failing step explaining what is happening instead of expected behavior
+- Do not ask user questions; do the most reasonable thing possible to pass the test
+- Never wait for networkidle or use other discouraged or deprecated APIs

--- a/tests/e2e/.claude/agents/playwright-test-planner.md
+++ b/tests/e2e/.claude/agents/playwright-test-planner.md
@@ -1,0 +1,111 @@
+---
+name: playwright-test-planner
+description: Use this agent when you need to create a comprehensive test plan for a web application or website
+tools: Bash, Glob, Grep, Read, Write
+model: sonnet
+color: green
+---
+
+You are an expert web test planner with extensive experience in quality assurance, user experience testing, and test
+scenario design. Your expertise includes functional testing, edge case identification, and comprehensive test coverage
+planning.
+
+You use `playwright-cli` bash commands for browser interaction and the `@anaconda/playwright-utils` library patterns
+when describing test implementation steps.
+
+## File Discovery
+
+When the user does not specify where to save the test plan:
+
+1. Check `specs/` for existing test plans for the same app/URL
+2. If one exists, ask the user whether to update it or create a new one
+3. New plans: `specs/{app}-test-plan.md` (kebab-case, match the app/domain name)
+
+## Browser Strategy
+
+Follow the tiered approach in `references/browser-strategy.md`:
+
+1. **Start with `WebFetch`** to fetch the target URL and understand page structure, navigation, and content
+2. **Escalate to `playwright-cli`** when you need interactive element discovery, JS-rendered content, or auth-gated pages
+3. If `WebFetch` returns minimal HTML (SPA shell like `<div id="root">`), go straight to browser
+
+User override: "use browser mode" = skip WebFetch; "use lite mode" = maximize WebFetch.
+
+You will:
+
+1. **Reconnaissance (Lite)**
+   - Use `WebFetch` to fetch the target URL and get an initial view of the page
+   - Identify navigation links, content sections, and form areas from the HTML
+   - **SPA detection:** If the response body contains only a minimal shell — e.g. `<div id="root">`, `<div id="app">`, or `<div id="__next">` with no meaningful content — the page is JavaScript-rendered. Skip immediately to step 2 (browser).
+
+2. **Interactive Exploration (Browser)**
+   - Open the target URL: `playwright-cli open <url>`
+   - Take a snapshot to see the page structure: `playwright-cli snapshot`
+   - Do not take screenshots unless absolutely necessary
+   - Use `playwright-cli` commands to navigate and discover the interface:
+     - `playwright-cli click <ref>` to interact with elements
+     - `playwright-cli goto <url>` to navigate to different pages
+     - `playwright-cli go-back` / `playwright-cli go-forward` for navigation
+   - Thoroughly explore the interface, identifying all interactive elements, forms, navigation paths, and functionality
+
+3. **Analyze User Flows**
+   - Map out the primary user journeys and identify critical paths through the application
+   - Consider different user types and their typical behaviors
+
+4. **Design Comprehensive Scenarios**
+
+   Create detailed test scenarios that cover:
+   - Happy path scenarios (normal user behavior)
+   - Edge cases and boundary conditions
+   - Error handling and validation
+
+   **Excluded suites — do NOT generate test plans or test cases for:**
+   - Responsive behavior and accessibility (screen sizes, ARIA, WCAG)
+   - Performance and load times (page speed, LCP, TTI, etc.)
+   - Browser compatibility (the project targets Chromium only)
+   - Network errors on page loads (offline mode, failed requests at navigation time)
+
+5. **Structure Test Plans**
+
+   Each scenario must include:
+   - Clear, descriptive title
+   - Detailed step-by-step instructions using `@anaconda/playwright-utils` function names where applicable:
+     - Navigation: `gotoURL(url)`, `clickAndNavigate(selector)`
+     - Actions: `click(selector)`, `fill(selector, value)`, `check(selector)`, `selectByText(selector, text)`
+     - Assertions: `expectElementToBeVisible(selector)`, `expectElementToHaveText(selector, text)`, `expectPageToHaveURL(url)`
+     - Data retrieval: `getText(selector)`, `getInputValue(selector)`, `isElementVisible(selector)`
+   - Expected outcomes where appropriate
+   - Assumptions about starting state (always assume blank/fresh state)
+   - Success criteria and failure conditions
+
+6. **Create Documentation**
+
+   Save the test plan using the `Write` tool as a markdown file in the `specs/` directory.
+
+**Quality Standards**:
+
+- Write steps that are specific enough for any tester to follow
+- Include negative testing scenarios
+- Ensure scenarios are independent and can be run in any order
+- Reference `@anaconda/playwright-utils` functions in step descriptions so tests can be directly implemented
+- Follow the locator strategy priority in `references/locators.md` when noting selectors (prefer data-qa-id, data-testid, role, label over CSS/XPath)
+- When noting suggested page object names, follow the class-based POM convention:
+  - Class name: `PascalCase` matching the page (e.g., `LoginPage`, `CheckoutPage`)
+  - File name: `kebab-case` in `tests/pages/` (e.g., `tests/pages/login-page.ts`)
+  - Action methods: verb + noun (e.g., `fillLoginForm`, `clickSubmit`)
+  - Verification methods: `verify*` prefix (e.g., `verifyLoginPageLoaded`, `verifyErrorMessage`)
+  - Data retrieval methods: `get*` prefix (e.g., `getWelcomeText`, `getCartCount`)
+- **Fixture registration:** For every new page object class suggested, note that it must be registered in `tests/fixtures/fixture.ts` using the `baseTest.extend<>()` pattern before it can be used in specs:
+  ```typescript
+  export const test = baseTest.extend<{ loginPage: LoginPage }>({
+    loginPage: async ({}, use) => {
+      await use(new LoginPage());
+    },
+  });
+  ```
+
+**Output Format**: Save the complete test plan as a markdown file with clear headings, numbered steps, and
+professional formatting suitable for sharing with development and QA teams.
+
+7. **Close Browser**
+   - When exploration is complete, close the browser: `playwright-cli close`

--- a/tests/e2e/.claude/skills/anaconda-playwright-utils/SKILL.md
+++ b/tests/e2e/.claude/skills/anaconda-playwright-utils/SKILL.md
@@ -1,0 +1,371 @@
+---
+name: anaconda-playwright-utils
+description: >
+  Use this skill whenever writing, editing, or reviewing Playwright TypeScript tests that use the @anaconda/playwright-utils library.
+  Trigger on requests like: "write a test for...", "create a page object for...", "add a spec file for...", "how do I click/fill/assert in Playwright?", "write a test that navigates to...", "generate tests for this page", or any task involving Playwright test code in a project that uses @anaconda/playwright-utils.
+  This skill ensures correct use of the library's utility functions (click, fill, gotoURL, expectElementToBeVisible, etc.) instead of raw Playwright API calls, correct class-based Page Object Model structure, proper fixture wiring, locator priority, and all test writing conventions.
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+---
+
+# @anaconda/playwright-utils
+
+A Playwright TypeScript utility library that simplifies browser automation with reusable helper functions for actions, assertions, locators, element queries, page management, and API requests.
+
+## Setup Requirement
+
+The library uses a singleton `page` pattern. `setPage(page)` must be called once per test before any utility function runs — but **the fixture handles this automatically**. When you import `test` from `@fixture`, `setPage(page)` is called before every test without any manual setup.
+
+```typescript
+import { test } from '@fixture'; // setPage(page) is called automatically — nothing else needed
+```
+
+Only call `setPage(page)` manually if you are NOT using the fixture (e.g., raw `@playwright/test` in a standalone script).
+
+## Import Patterns
+
+### Main export (all utilities)
+
+```typescript
+import { click, fill, expectElementToBeVisible, getLocator, logger } from '@anaconda/playwright-utils';
+```
+
+> **`logger`** is a Winston-based logger exported from the library. Use it in page objects only for informational or warning messages — never in spec files and never with `console.log`.
+
+### Subpath exports (tree-shakable)
+
+```typescript
+import { click, fill, clickAndNavigate } from '@anaconda/playwright-utils/action-utils';
+import { expectElementToBeVisible, expectPageToHaveURL } from '@anaconda/playwright-utils/assert-utils';
+import { getLocator, getLocatorByRole, getLocatorByText } from '@anaconda/playwright-utils/locator-utils';
+import { getText, isElementVisible, waitForElementToBeVisible } from '@anaconda/playwright-utils/element-utils';
+import { gotoURL, switchPage, getPage, setPage } from '@anaconda/playwright-utils/page-utils';
+import { getRequest, postRequest } from '@anaconda/playwright-utils/api-utils';
+import { ClickOptions, FillOptions } from '@anaconda/playwright-utils/types';
+import logger from '@anaconda/playwright-utils'; // named default export for logger
+```
+
+## Core Pattern
+
+Most functions accept `string | Locator` as their first argument (the `input` parameter). This means you can pass either a CSS/XPath selector string or a Playwright `Locator` object.
+
+Action functions enforce **visibility by default** (`onlyVisible: true`). Override with `{ onlyVisible: false }`.
+
+Most functions accept an optional `options` object as the last parameter, extending Playwright's native options with:
+
+- `onlyVisible?: boolean` - Filter to visible elements only (default: `true` for actions)
+- `stable?: boolean` - Wait for element position to stabilize before acting
+- `loadState?: WaitForLoadStateOptions` - Wait for load state after navigation actions
+- `soft?: boolean` - Use soft assertions (won't stop test on failure)
+
+## Module Reference
+
+### Action Utils (`action-utils`)
+
+Interact with page elements.
+
+| Function                | Signature                                       | Description                                   |
+| ----------------------- | ----------------------------------------------- | --------------------------------------------- |
+| `click`                 | `(input, options?: ClickOptions)`               | Click an element                              |
+| `clickAndNavigate`      | `(input, options?: ClickOptions)`               | Click and wait for navigation                 |
+| `fill`                  | `(input, value: string, options?: FillOptions)` | Fill an input field                           |
+| `fillAndEnter`          | `(input, value, options?)`                      | Fill and press Enter                          |
+| `fillAndTab`            | `(input, value, options?)`                      | Fill and press Tab                            |
+| `pressSequentially`     | `(input, value, options?)`                      | Type character by character                   |
+| `pressPageKeyboard`     | `(key, options?)`                               | Press key on the page                         |
+| `pressLocatorKeyboard`  | `(input, key, options?)`                        | Press key on an element                       |
+| `clear`                 | `(input, options?)`                             | Clear an input field                          |
+| `check`                 | `(input, options?)`                             | Check a checkbox/radio                        |
+| `uncheck`               | `(input, options?)`                             | Uncheck a checkbox/radio                      |
+| `selectByValue`         | `(input, value, options?)`                      | Select dropdown by value                      |
+| `selectByValues`        | `(input, values[], options?)`                   | Multi-select by values                        |
+| `selectByText`          | `(input, text, options?)`                       | Select dropdown by label text                 |
+| `selectByIndex`         | `(input, index, options?)`                      | Select dropdown by index                      |
+| `hover`                 | `(input, options?)`                             | Hover over an element                         |
+| `focus`                 | `(input, options?)`                             | Focus an element                              |
+| `dragAndDrop`           | `(input, dest, options?)`                       | Drag and drop                                 |
+| `doubleClick`           | `(input, options?)`                             | Double-click an element                       |
+| `downloadFile`          | `(input, savePath, options?)`                   | Click to download, save file, return filename |
+| `uploadFiles`           | `(input, path, options?)`                       | Upload files to an input                      |
+| `scrollLocatorIntoView` | `(input, options?)`                             | Scroll element into view                      |
+| `clickByJS`             | `(input, options?)`                             | Click via JavaScript (bypasses visibility)    |
+| `clearByJS`             | `(input, options?)`                             | Clear input via JavaScript                    |
+| `acceptAlert`           | `(input, options?)`                             | Click, accept dialog, return message          |
+| `dismissAlert`          | `(input, options?)`                             | Click, dismiss dialog, return message         |
+| `getAlertText`          | `(input, options?)`                             | Click, get dialog text, dismiss               |
+
+### Assert Utils (`assert-utils`)
+
+Playwright auto-retrying assertions.
+
+| Function                          | Signature                          | Description                          |
+| --------------------------------- | ---------------------------------- | ------------------------------------ |
+| `expectElementToBeVisible`        | `(input, options?: ExpectOptions)` | Assert element is visible            |
+| `expectElementToBeHidden`         | `(input, options?)`                | Assert element is hidden/not in DOM  |
+| `expectElementToBeAttached`       | `(input, options?)`                | Assert element is in DOM             |
+| `expectElementToBeInViewport`     | `(input, options?)`                | Assert element is in viewport        |
+| `expectElementNotToBeInViewport`  | `(input, options?)`                | Assert element is not in viewport    |
+| `expectElementToBeChecked`        | `(input, options?)`                | Assert checkbox is checked           |
+| `expectElementNotToBeChecked`     | `(input, options?)`                | Assert checkbox is not checked       |
+| `expectElementToBeDisabled`       | `(input, options?)`                | Assert element is disabled           |
+| `expectElementToBeEnabled`        | `(input, options?)`                | Assert element is enabled            |
+| `expectElementToBeEditable`       | `(input, options?)`                | Assert element is editable           |
+| `expectElementToHaveText`         | `(input, text, options?)`          | Assert element text equals           |
+| `expectElementNotToHaveText`      | `(input, text, options?)`          | Assert element text does not equal   |
+| `expectElementToContainText`      | `(input, text, options?)`          | Assert element text contains         |
+| `expectElementNotToContainText`   | `(input, text, options?)`          | Assert element text does not contain |
+| `expectElementToHaveValue`        | `(input, text, options?)`          | Assert input has value               |
+| `expectElementToHaveValues`       | `(input, texts[], options?)`       | Assert multi-select has values       |
+| `expectElementValueToBeEmpty`     | `(input, options?)`                | Assert input is empty                |
+| `expectElementValueNotToBeEmpty`  | `(input, options?)`                | Assert input is not empty            |
+| `expectElementToHaveAttribute`    | `(input, attr, value, options?)`   | Assert element has attribute value   |
+| `expectElementToContainAttribute` | `(input, attr, value, options?)`   | Assert attribute contains value      |
+| `expectElementToHaveCount`        | `(input, count, options?)`         | Assert element count                 |
+| `expectPageToHaveURL`             | `(urlOrRegExp, options?)`          | Assert page URL                      |
+| `expectPageToContainURL`          | `(url, options?)`                  | Assert page URL contains             |
+| `expectPageToHaveTitle`           | `(titleOrRegExp, options?)`        | Assert page title                    |
+| `expectPageSizeToBeEqualTo`       | `(count, options?)`                | Assert number of open pages          |
+| `expectAlertToHaveText`           | `(input, text, options?)`          | Assert alert text equals             |
+| `expectAlertToMatchText`          | `(input, text, options?)`          | Assert alert text matches            |
+| `assertAllSoftAssertions`         | `(testInfo)`                       | Verify all soft assertions passed    |
+
+### Locator Utils (`locator-utils`)
+
+Find elements on the page.
+
+| Function                  | Signature                           | Description                                                                   |
+| ------------------------- | ----------------------------------- | ----------------------------------------------------------------------------- |
+| `getLocator`              | `(input, options?: LocatorOptions)` | Get locator from selector or Locator                                          |
+| `getVisibleLocator`       | `(input, options?)`                 | Get locator filtered to visible elements                                      |
+| `getLocatorByTestId`      | `(testId)`                          | Get locator by the configured `testIdAttribute` (`data-qa-id`, `data-testid`) |
+| `getLocatorByText`        | `(text, options?)`                  | Get locator by text content                                                   |
+| `getLocatorByRole`        | `(role, options?)`                  | Get locator by ARIA role                                                      |
+| `getLocatorByLabel`       | `(text, options?)`                  | Get locator by label                                                          |
+| `getLocatorByPlaceholder` | `(text, options?)`                  | Get locator by placeholder                                                    |
+| `getAllLocators`          | `(input, options?)`                 | Get all matching locators                                                     |
+| `getFrame`                | `(frameSelector, options?)`         | Get a Frame by name/URL                                                       |
+| `getFrameLocator`         | `(frameInput)`                      | Get a FrameLocator                                                            |
+| `getLocatorInFrame`       | `(frameInput, input)`               | Get locator within a frame                                                    |
+
+### Element Utils (`element-utils`)
+
+Retrieve data and check element state.
+
+| Function                          | Signature                     | Description                                       |
+| --------------------------------- | ----------------------------- | ------------------------------------------------- |
+| `getText`                         | `(input, options?)`           | Get inner text (trimmed)                          |
+| `getAllTexts`                     | `(input, options?)`           | Get all inner texts                               |
+| `getInputValue`                   | `(input, options?)`           | Get input value (trimmed)                         |
+| `getAllInputValues`               | `(input, options?)`           | Get all input values                              |
+| `getAttribute`                    | `(input, attrName, options?)` | Get attribute value                               |
+| `getLocatorCount`                 | `(input, options?)`           | Get count of matching elements                    |
+| `isElementAttached`               | `(input, options?)`           | Check if element is in DOM                        |
+| `isElementVisible`                | `(input, options?)`           | Check if element is visible                       |
+| `isElementHidden`                 | `(input, options?)`           | Check if element is hidden                        |
+| `isElementChecked`                | `(input, options?)`           | Check if checkbox is checked                      |
+| `waitForElementToBeStable`        | `(input, options?)`           | Wait for element position to stabilize            |
+| `waitForElementToBeVisible`       | `(input, options?)`           | Wait for element to be visible                    |
+| `waitForElementToBeHidden`        | `(input, options?)`           | Wait for element to be hidden                     |
+| `waitForElementToBeAttached`      | `(input, options?)`           | Wait for element to attach to DOM                 |
+| `waitForElementToBeDetached`      | `(input, options?)`           | Wait for element to detach from DOM               |
+| `waitForFirstElementToBeAttached` | `(input, options?)`           | Wait for the first of multiple elements to attach |
+
+### Page Utils (`page-utils`)
+
+Page management and navigation.
+
+| Function               | Signature            | Description                       |
+| ---------------------- | -------------------- | --------------------------------- |
+| `getPage`              | `()`                 | Get current Page instance         |
+| `setPage`              | `(pageInstance)`     | Set current Page instance         |
+| `getContext`           | `()`                 | Get current BrowserContext        |
+| `getAllPages`          | `()`                 | Get all pages in context          |
+| `switchPage`           | `(winNum, options?)` | Switch to page by index (1-based) |
+| `switchToDefaultPage`  | `()`                 | Switch to first page              |
+| `closePage`            | `(winNum?)`          | Close page by index               |
+| `gotoURL`              | `(path, options?)`   | Navigate to URL                   |
+| `getURL`               | `(options?)`         | Get current page URL              |
+| `waitForPageLoadState` | `(options?)`         | Wait for page load state          |
+| `reloadPage`           | `(options?)`         | Reload current page               |
+| `goBack`               | `(options?)`         | Navigate back                     |
+| `wait`                 | `(ms)`               | Wait for specified milliseconds   |
+| `getWindowSize`        | `()`                 | Get browser window dimensions     |
+| `saveStorageState`     | `(path?)`            | Save cookies/storage to file      |
+
+### API Utils (`api-utils`)
+
+HTTP requests via Playwright's API context.
+
+| Function               | Signature         | Description               |
+| ---------------------- | ----------------- | ------------------------- |
+| `getAPIRequestContext` | `()`              | Get the APIRequestContext |
+| `getRequest`           | `(url, options?)` | Send GET request          |
+| `postRequest`          | `(url, options?)` | Send POST request         |
+| `putRequest`           | `(url, options?)` | Send PUT request          |
+| `patchRequest`         | `(url, options?)` | Send PATCH request        |
+| `deleteRequest`        | `(url, options?)` | Send DELETE request       |
+
+## Example Test
+
+Tests are always structured with three files: a **Page Object class**, a **Fixture** registration, and a **Spec** file. All actions and assertions live in the page object class — the spec only calls page object methods via injected fixtures.
+
+### Page Object Class (`tests/pages/login-page.ts`)
+
+```typescript
+import {
+  click,
+  clickAndNavigate,
+  expectElementToBeAttached,
+  expectElementToBeVisible,
+  fill,
+  getLocator,
+  getLocatorByPlaceholder,
+  getLocatorByRole,
+  gotoURL,
+} from '@anaconda/playwright-utils';
+import { urlData } from '@testdata/urls-testdata';
+import { validUser, invalidUser } from '@testdata/user-testdata';
+
+export class LoginPage {
+  // Static selectors — plain strings for simple CSS/XPath
+  private readonly usernameInput = '#username';
+  private readonly welcomeMessage = '[data-test="welcome-message"]';
+  private readonly errorMessage = '[data-test="error-message"]';
+
+  // Dynamic locators — arrow functions for chained or compound locators
+  private readonly passwordInput = () => getLocator('#password').or(getLocatorByPlaceholder('Password'));
+  private readonly loginButton = () => getLocatorByRole('button', { name: 'Login' });
+
+  async navigateToLoginPage(): Promise<void> {
+    await gotoURL(urlData.loginPageUrl);
+  }
+
+  async loginWithValidCredentials(username = validUser.username, password = validUser.pwd): Promise<void> {
+    await fill(this.usernameInput, username);
+    await fill(this.passwordInput(), password);
+    await clickAndNavigate(this.loginButton());
+    await expectElementToBeAttached(this.welcomeMessage, 'User should be logged in successfully');
+  }
+
+  async loginWithInvalidCredentials(username = invalidUser.username, password = invalidUser.pwd): Promise<void> {
+    await fill(this.usernameInput, username);
+    await fill(this.passwordInput(), password);
+    await click(this.loginButton());
+    await expectElementToBeVisible(this.errorMessage, 'Error message should be displayed for invalid credentials');
+  }
+
+  async verifyLoginPageIsDisplayed(): Promise<void> {
+    await expectElementToBeVisible(this.usernameInput, 'Login page should be displayed');
+  }
+}
+```
+
+### Fixture Registration (`tests/fixtures/fixture.ts`)
+
+```typescript
+import { test as baseTest } from '@anaconda/playwright-utils';
+import { LoginPage } from '@pages/login-page';
+import { ProductsPage } from '@pages/products-page';
+
+export const test = baseTest.extend<{
+  loginPage: LoginPage;
+  productsPage: ProductsPage;
+}>({
+  loginPage: async ({}, use) => {
+    await use(new LoginPage());
+  },
+  productsPage: async ({}, use) => {
+    await use(new ProductsPage());
+  },
+});
+```
+
+### Spec File (`tests/specs/login.spec.ts`)
+
+```typescript
+import { test } from '@fixture';
+
+test.describe('Login @smoke', () => {
+  test.beforeEach(async ({ loginPage }) => {
+    await loginPage.navigateToLoginPage();
+  });
+
+  test('should login with valid credentials', async ({ loginPage }) => {
+    await loginPage.loginWithValidCredentials();
+  });
+
+  test('should show error with invalid credentials', async ({ loginPage }) => {
+    await loginPage.loginWithInvalidCredentials();
+    await loginPage.verifyLoginPageIsDisplayed();
+  });
+});
+```
+
+**Key rules:**
+
+- Import `test` from `@fixture` — this auto-calls `setPage(page)` before each test (no manual setup needed)
+- Page objects are classes registered in `fixture.ts` and injected via destructuring: `async ({ loginPage }) => {}`
+- **No actions or assertions in spec files** — `fill`, `click`, `gotoURL`, `expectElementToBeVisible`, etc. all belong in the page object class; spec files only call page object methods
+- **No raw `expect()` in spec files** — use `verify*` methods in page objects instead
+- Wrap all tests in a `test.describe` block with a descriptive name and tag (`@smoke`, `@reg`)
+- Use `test.beforeEach` for shared setup (navigation, login) that every test in the describe needs
+
+## CLI-to-Library Code Mapping
+
+When using `playwright-cli` to explore pages, translate the generated Playwright code to `@anaconda/playwright-utils` equivalents:
+
+| playwright-cli Generated Code                      | @anaconda/playwright-utils Equivalent        |
+| -------------------------------------------------- | -------------------------------------------- |
+| `await page.goto(url)`                             | `await gotoURL(url)`                         |
+| `await page.goBack()`                              | `await goBack()`                             |
+| `await page.reload()`                              | `await reloadPage()`                         |
+| `await page.locator(sel).click()`                  | `await click(sel)`                           |
+| `await page.locator(sel).click()` + navigation     | `await clickAndNavigate(sel)`                |
+| `await page.locator(sel).dblclick()`               | `await doubleClick(sel)`                     |
+| `await page.locator(sel).fill(val)`                | `await fill(sel, val)`                       |
+| `await page.locator(sel).fill(val)` + Enter        | `await fillAndEnter(sel, val)`               |
+| `await page.locator(sel).hover()`                  | `await hover(sel)`                           |
+| `await page.locator(sel).check()`                  | `await check(sel)`                           |
+| `await page.locator(sel).uncheck()`                | `await uncheck(sel)`                         |
+| `await page.locator(sel).selectOption(val)`        | `await selectByValue(sel, val)`              |
+| `await page.locator(sel).dragTo(dest)`             | `await dragAndDrop(sel, dest)`               |
+| `await page.keyboard.press(key)`                   | `await pressPageKeyboard(key)`               |
+| `page.getByRole(role, opts)`                       | `getLocatorByRole(role, opts)`               |
+| `page.getByText(text)`                             | `getLocatorByText(text)`                     |
+| `page.getByTestId(id)`                             | `getLocatorByTestId(id)`                     |
+| `page.getByLabel(text)`                            | `getLocatorByLabel(text)`                    |
+| `page.getByPlaceholder(text)`                      | `getLocatorByPlaceholder(text)`              |
+| `await expect(loc).toBeVisible()`                  | `await expectElementToBeVisible(input)`      |
+| `await expect(loc).toBeHidden()`                   | `await expectElementToBeHidden(input)`       |
+| `await expect(loc).toHaveText(t)`                  | `await expectElementToHaveText(input, t)`    |
+| `await expect(loc).toContainText(t)`               | `await expectElementToContainText(input, t)` |
+| `await expect(loc).toHaveValue(v)`                 | `await expectElementToHaveValue(input, v)`   |
+| `await expect(loc).toBeChecked()`                  | `await expectElementToBeChecked(input)`      |
+| `await expect(loc).toBeEnabled()`                  | `await expectElementToBeEnabled(input)`      |
+| `await expect(loc).toBeDisabled()`                 | `await expectElementToBeDisabled(input)`     |
+| `await expect(page).toHaveURL(url)`                | `await expectPageToHaveURL(url)`             |
+| `await expect(page).toHaveTitle(t)`                | `await expectPageToHaveTitle(t)`             |
+| `await page.locator(sel).innerText()`              | `await getText(sel)`                         |
+| `await page.locator(sel).inputValue()`             | `await getInputValue(sel)`                   |
+| `await page.locator(sel).getAttribute(a)`          | `await getAttribute(sel, a)`                 |
+| `await page.locator(sel).isVisible()`              | `await isElementVisible(sel)`                |
+| `await page.locator(sel).isHidden()`               | `await isElementHidden(sel)`                 |
+| `await page.locator(sel).count()`                  | `await getLocatorCount(sel)`                 |
+| `await request.get(url, opts)`                     | `await getRequest(url, opts)`                |
+| `await request.post(url, opts)`                    | `await postRequest(url, opts)`               |
+| `await request.put(url, opts)`                     | `await putRequest(url, opts)`                |
+| `await request.delete(url, opts)`                  | `await deleteRequest(url, opts)`             |
+| `await page.locator(sel).scrollIntoViewIfNeeded()` | `await scrollLocatorIntoView(sel)`           |
+
+See `references/` for detailed documentation on specific modules:
+
+- `references/actions.md` — Click, fill, select, drag, upload, keyboard, alerts (27 functions)
+- `references/assertions.md` — Visibility, text, value, attribute, page assertions (28 functions)
+- `references/locators.md` — Locator strategy, finding elements, frames (11 functions)
+- `references/element-utils.md` — Data retrieval, element state checks, waits (16 functions)
+- `references/api-utils.md` — HTTP requests via APIRequestContext (6 functions)
+- `references/page-utils.md` — Page management, navigation, multi-tab handling (15 functions)
+- `references/browser-strategy.md` — When to use WebFetch vs playwright-cli for optimal token usage

--- a/tests/e2e/.claude/skills/anaconda-playwright-utils/references/actions.md
+++ b/tests/e2e/.claude/skills/anaconda-playwright-utils/references/actions.md
@@ -1,0 +1,458 @@
+# Action Utils Reference
+
+Source: `src/playwright-utils/utils/action-utils.ts`
+
+## Overview
+
+Action utils provide functions for interacting with page elements. All action functions:
+
+- Accept `string | Locator` as the first `input` parameter
+- Enforce visibility by default (`onlyVisible: true`)
+- Support `stable: true` option to wait for element position stability
+- Return `Promise<void>` unless noted otherwise
+
+**Important:**
+
+- ✅ All actions go in page object methods, not spec files
+- ✅ Never use `console.log()` or `console.error()` in tests
+- ✅ If logging is needed, use `logger` from `@anaconda/playwright-utils` minimally in page objects only
+- ✅ Spec files should call page object methods, never call actions directly
+
+## Click Actions
+
+### `click(input, options?: ClickOptions)`
+
+Clicks on a visible element. Supports all Playwright click options plus `onlyVisible` and `stable`.
+
+**Use this for:** AJAX calls, same-page interactions, dropdown toggles, modal opens — anything that doesn't navigate to a new page.
+
+```typescript
+await click('#add-to-cart-button'); // AJAX call, stays on same page
+await click('.menu-toggle'); // Opens dropdown on same page
+```
+
+### `clickAndNavigate(input, options?: ClickOptions)`
+
+Clicks and waits for page navigation (framenavigated event + load state). **Use this instead of `click` when the click triggers a full page navigation.**
+
+**Use this for:** Links that navigate to different pages, form submissions that redirect, any click that loads a new page.
+
+```typescript
+await clickAndNavigate('a[href="/checkout"]'); // Navigate to checkout page
+await clickAndNavigate('#login-button'); // Navigate to dashboard after login
+```
+
+**When to use which:**
+
+- **`click()`** = No page navigation (stays on same page)
+- **`clickAndNavigate()`** = Page navigation occurs (new page loads)
+
+**`clickAndNavigate` already handles all post-navigation waiting** — it waits for the `framenavigated` event, the page load state, and the clicked element to go stale/hidden. Never add `waitForPageLoadState` after it:
+
+```typescript
+// ❌ Redundant — waitForPageLoadState is already done internally
+await clickAndNavigate(this.loginButton());
+await waitForPageLoadState({ waitUntil: 'load' });
+
+// ✅ Correct
+await clickAndNavigate(this.loginButton());
+```
+
+### `doubleClick(input, options?: DoubleClickOptions)`
+
+Double-clicks on a visible element.
+
+```typescript
+await doubleClick('.text-field'); // Select all text
+```
+
+### `clickByJS(input, options?: TimeoutOption)`
+
+Clicks using JavaScript `el.click()`. Bypasses visibility checks. Use only when standard click fails.
+
+```typescript
+// Only use if click() fails due to overlapping elements or CSS issues
+await clickByJS('.hidden-button', { timeout: SMALL_TIMEOUT });
+```
+
+## Input Actions
+
+### `fill(input, value: string, options?: FillOptions)`
+
+Fills an input field, replacing existing content. **Use this as the default for all form field filling.**
+
+```typescript
+await fill('#username', userData.userName);
+await fill('#password', userData.pwd);
+```
+
+### `fillAndEnter(input, value: string, options?: FillOptions)`
+
+Fills an input field then presses Enter. Use for search fields and forms that submit on Enter.
+
+```typescript
+await fillAndEnter('#search-input', searchData.query); // Fills and presses Enter
+```
+
+### `fillAndTab(input, value: string, options?: FillOptions)`
+
+Fills an input field then presses Tab. Use to move to the next field.
+
+```typescript
+await fillAndTab('#first-name', userData.firstName); // Fills and moves to next field
+```
+
+### `pressSequentially(input, value: string, options?: PressSequentiallyOptions)`
+
+Types value character by character, simulating keyboard press events. **Use this only when testing features that require character-by-character typing** like auto-search, autocomplete, or autofill.
+
+**Use `fill()` by default, use `pressSequentially()` only for:**
+
+- Auto-search suggestions (need to trigger on each character)
+- Autocomplete features (need intermediate results)
+- Autofill testing (need to see progressive changes)
+
+```typescript
+// Default: Use fill() for normal form filling
+await fill('#email', userData.email);
+
+// Special case: Use pressSequentially() for auto-search
+await pressSequentially('#search', searchData.query); // Triggers API calls per character
+// Server responds to 'j', then 'ja', then 'jav', then 'java'
+```
+
+### `clear(input, options?: ClearOptions)`
+
+Clears an input field.
+
+```typescript
+await clear('#input-field'); // Clears existing content
+```
+
+### `clearByJS(input, options?: TimeoutOption)`
+
+Clears input using JavaScript, dispatches `input` and `change` events. Use only when `clear()` doesn't work.
+
+```typescript
+// Only if clear() fails to trigger change events
+await clearByJS('.special-input', { timeout: SMALL_TIMEOUT });
+```
+
+## Keyboard Actions
+
+### `pressPageKeyboard(key: string, options?: PressSequentiallyOptions)`
+
+Presses a key on the page (not on a specific element). Example: `pressPageKeyboard('Escape')`.
+
+### `pressLocatorKeyboard(input, key: string, options?: PressSequentiallyOptions)`
+
+Presses a key on a specific element. Example: `pressLocatorKeyboard('#search', 'Enter')`.
+
+## Selection Actions
+
+### `selectByValue(input, value: string, options?: SelectOptions)`
+
+Selects a dropdown option by its `value` attribute.
+
+### `selectByValues(input, values: string[], options?: SelectOptions)`
+
+Multi-select by `value` attributes.
+
+### `selectByText(input, text: string, options?: SelectOptions)`
+
+Selects a dropdown option by its visible text (label).
+
+### `selectByIndex(input, index: number, options?: SelectOptions)`
+
+Selects a dropdown option by its zero-based index.
+
+## Checkbox/Radio
+
+### `check(input, options?: CheckOptions)`
+
+Checks a checkbox or radio button. **Use this as the default for checkboxes/radios.**
+
+```typescript
+await check('#agree-terms-checkbox');
+await check('input[name="subscription"]'); // Select radio option
+```
+
+### `uncheck(input, options?: CheckOptions)`
+
+Unchecks a checkbox. **Use this to deselect checkboxes.**
+
+```typescript
+await uncheck('#optional-newsletter');
+```
+
+**When `check()/uncheck()` are unreliable:** If you find these functions behave inconsistently, use `click()` as a fallback. This allows you to click the checkbox like a user would:
+
+```typescript
+// If check() is unreliable:
+await click('#checkbox-label'); // Click the label or checkbox directly
+```
+
+## Mouse Actions
+
+### `hover(input, options?: HoverOptions)`
+
+Hovers over an element.
+
+### `focus(input, options?)`
+
+Focuses on an element.
+
+### `dragAndDrop(input, dest, options?: DragOptions)`
+
+Drags element `input` and drops on element `dest`. Both accept `string | Locator`.
+
+## File Actions
+
+### `downloadFile(input, savePath: string, options?: ClickOptions): Promise<string>`
+
+Clicks the element to trigger a download, saves to `savePath`, returns the suggested filename. Works with remote browsers.
+
+### `uploadFiles(input, path: UploadValues, options?: UploadOptions)`
+
+Uploads files to a file input element.
+
+## Other
+
+### `scrollLocatorIntoView(input, options?: TimeoutOption)`
+
+Scrolls the element into view if it is not currently visible in the viewport.
+
+**Parameters:**
+
+- `input` — CSS/XPath selector string or Locator
+- `options.timeout` — Maximum wait time (default: ACTION_TIMEOUT)
+
+**When to use:** Use before interacting with elements that are outside the viewport (e.g., elements far down a long page, or inside a scrollable container). Most action functions scroll automatically, but `scrollLocatorIntoView` is useful when you need to scroll without performing any other action — for example, to trigger lazy-loaded content or verify visual presence in a scrollable area.
+
+**Example:**
+
+```typescript
+// Scroll a footer element into view before asserting visibility
+await scrollLocatorIntoView('[data-qa-id="footer-links"]');
+await expectElementToBeVisible('[data-qa-id="footer-links"]', 'Footer links should be visible after scroll');
+
+// In a page object
+async verifyLazyLoadedContent(): Promise<void> {
+  await scrollLocatorIntoView(this.lazySection());
+  await expectElementToBeVisible(this.lazySection(), 'Lazy section should load after scrolling into view');
+}
+```
+
+## Alert/Dialog Actions
+
+### `acceptAlert(input, options?): Promise<string>`
+
+Clicks element, accepts the resulting dialog (optionally with prompt text), returns dialog message.
+Options: `{ promptText?: string, timeout?: number }`
+
+### `dismissAlert(input, options?): Promise<string>`
+
+Clicks element, dismisses the resulting dialog, returns dialog message.
+
+### `getAlertText(input, options?): Promise<string>`
+
+Clicks element, gets dialog message text, dismisses it, returns the message.
+
+## Page Object Model Examples
+
+### Login Form Example
+
+**Page Object (tests/pages/login-page.ts):**
+
+```typescript
+import {
+  gotoURL,
+  fill,
+  fillAndEnter,
+  click,
+  clickAndNavigate,
+  expectElementToBeVisible,
+  expectPageToHaveURL,
+} from '@anaconda/playwright-utils';
+import { urlData } from '@testdata/urls-testdata';
+import { adminUserData, nonAdminUserData } from '@testdata/user-testdata';
+
+export class LoginPage {
+  private readonly usernameField = '#username';
+  private readonly passwordField = '#password';
+  private readonly loginButton = '#login-button';
+  private readonly errorMessage = '.error-message';
+
+  async navigateToLogin() {
+    await gotoURL(urlData.loginPageUrl);
+    await expectElementToBeVisible(this.usernameField, {
+      message: 'Login page should display username field',
+    });
+  }
+
+  async login(username: string, password: string) {
+    await fill(this.usernameField, username);
+    await fill(this.passwordField, password);
+    await clickAndNavigate(this.loginButton);
+    await expectPageToHaveURL(/dashboard/, {
+      message: `User should be redirected to dashboard after login`,
+    });
+  }
+
+  async loginWithEnter(username: string, password: string) {
+    await fill(this.usernameField, username);
+    // Use fillAndEnter to submit on password field
+    await fillAndEnter(this.passwordField, password);
+    await expectPageToHaveURL(/dashboard/, {
+      message: 'Dashboard should load after entering password with Enter key',
+    });
+  }
+
+  async verifyErrorMessage(expectedError: string) {
+    await expectElementToBeVisible(this.errorMessage, {
+      message: `Error message should be displayed: ${expectedError}`,
+    });
+  }
+
+  async loginAsAdmin() {
+    await this.login(adminUserData.email, adminUserData.pwd);
+  }
+
+  async loginAsUser() {
+    await this.login(nonAdminUserData.email, nonAdminUserData.pwd);
+  }
+}
+```
+
+**Fixture (tests/fixtures/fixture.ts):**
+
+```typescript
+import { test as base } from '@anaconda/playwright-utils';
+import { LoginPage } from '@pages/login-page';
+import { userData } from '@testdata/user-testdata';
+
+export const test = base.extend({
+  loginPage: async ({}, use) => {
+    await use(new LoginPage());
+  },
+});
+```
+
+**Spec File (tests/specs/login.spec.ts):**
+
+```typescript
+import { test } from '@fixture';
+
+test.describe('Login @smoke', () => {
+  test.beforeEach(async ({ loginPage }) => {
+    await loginPage.navigateToLogin();
+  });
+
+  test('should login with valid credentials', async ({ loginPage }) => {
+    await loginPage.login(userData.email, userData.pwd);
+  });
+
+  test('should login as admin', async ({ loginPage }) => {
+    await loginPage.loginAsAdmin();
+  });
+
+  test('should login with enter key', async ({ loginPage }) => {
+    await loginPage.loginWithEnter(userData.email, userData.pwd);
+  });
+});
+```
+
+### Checkout Form Example
+
+**Page Object (tests/pages/checkout-page.ts):**
+
+```typescript
+import {
+  fill,
+  fillAndTab,
+  selectByValue,
+  check,
+  click,
+  clickAndNavigate,
+  expectElementToBeVisible,
+} from '@anaconda/playwright-utils';
+
+export class CheckoutPage {
+  async fillShippingAddress(firstName: string, lastName: string, address: string, city: string) {
+    await fill('#first-name', firstName);
+    await fill('#last-name', lastName);
+    await fill('#address', address);
+    await fillAndTab('#city', city); // Fill and move to next field
+  }
+
+  async selectShippingMethod(method: string) {
+    await selectByValue('#shipping-method', method);
+  }
+
+  async agreeToTermsAndCheckout() {
+    await check('#agree-terms');
+    await check('#newsletter-signup');
+    await clickAndNavigate('#place-order-button');
+    await expectElementToBeVisible('.order-confirmation', {
+      message: 'Order confirmation should display after successful checkout',
+    });
+  }
+
+  async completeCheckout(firstName: string, lastName: string, address: string, city: string, shippingMethod: string) {
+    await this.fillShippingAddress(firstName, lastName, address, city);
+    await this.selectShippingMethod(shippingMethod);
+    await this.agreeToTermsAndCheckout();
+  }
+}
+```
+
+**Fixture (tests/fixtures/fixture.ts):**
+
+```typescript
+import { test as base } from '@anaconda/playwright-utils';
+import { CheckoutPage } from '@pages/checkout-page';
+
+export const test = base.extend({
+  checkoutPage: async ({}, use) => {
+    await use(new CheckoutPage());
+  },
+});
+```
+
+**Spec File (tests/specs/checkout.spec.ts):**
+
+```typescript
+import { test } from '@fixture';
+import { userData } from '@testdata/user-testdata';
+enum Shipping {
+  STANDARD = 'standard',
+  EXPRESS = 'express',
+}
+
+test.describe('Checkout @reg', () => {
+  test('should complete checkout with standard shipping', async ({ checkoutPage }) => {
+    await checkoutPage.fillShippingAddress(userData.firstname, userData.lastName, userData.address, userData.city);
+    await checkoutPage.selectShippingMethod(Shipping.STANDARD);
+    await checkoutPage.agreeToTermsAndCheckout();
+  });
+
+  test('should complete checkout with express shipping', async ({ checkoutPage }) => {
+    await checkoutPage.fillShippingAddress(userData.firstname, userData.lastName, userData.address, userData.city);
+    await checkoutPage.selectShippingMethod(Shipping.EXPRESS);
+    await checkoutPage.agreeToTermsAndCheckout();
+  });
+});
+```
+
+## Option Types
+
+All option types extend Playwright's native options with:
+
+- `onlyVisible?: boolean` - Default `true` for action functions
+- `stable?: boolean` - Wait for element to stop moving before acting
+
+```typescript
+type ClickOptions = PlaywrightClickOptions & VisibilityOption & StabilityOption & LoadstateOption;
+type FillOptions = PlaywrightFillOptions & VisibilityOption & StabilityOption;
+// ... similar pattern for all option types
+```

--- a/tests/e2e/.claude/skills/anaconda-playwright-utils/references/api-utils.md
+++ b/tests/e2e/.claude/skills/anaconda-playwright-utils/references/api-utils.md
@@ -1,0 +1,364 @@
+# API Utils Reference
+
+Source: `src/playwright-utils/utils/api-utils.ts`
+
+## Overview
+
+API utils provide simplified HTTP request functions wrapping Playwright's `APIRequestContext`. These functions use the page's request context, so they automatically share cookies, authentication tokens, and storage with the browser session — making them ideal for testing API interactions alongside UI tests.
+
+All request functions return Playwright's `APIResponse` object, which provides methods for checking status, parsing body, and accessing headers.
+
+## Request Context
+
+### `getAPIRequestContext(): APIRequestContext`
+
+Returns the `APIRequestContext` from the current page. Equivalent to `page.request` in Playwright.
+
+**Usage:**
+
+```typescript
+const context = getAPIRequestContext();
+// Use for advanced scenarios not covered by the helper functions
+// (e.g., complex retry logic, custom interceptors)
+```
+
+## HTTP Request Functions
+
+All request functions return `Promise<APIResponse>`. Options are passed directly to Playwright's native APIRequestContext methods.
+
+### `getRequest(url, options?): Promise<APIResponse>`
+
+Performs an HTTP GET request.
+
+**Example:**
+
+```typescript
+const response = await getRequest('https://api.example.com/users/1');
+await expect(response).toBeOK();
+
+const user = await response.json();
+logger.info(`Retrieved user: ${user.name}`);
+```
+
+### `postRequest(url, options?): Promise<APIResponse>`
+
+Performs an HTTP POST request.
+
+**Example:**
+
+```typescript
+const response = await postRequest('https://api.example.com/users', {
+  data: {
+    name: 'John Doe',
+    email: 'john@example.com',
+  },
+});
+
+expect(response.status(), { message: 'POST should return 201 Created' }).toBe(201);
+const newUser = await response.json();
+logger.info(`Created user ID: ${newUser.id}`);
+```
+
+### `putRequest(url, options?): Promise<APIResponse>`
+
+Performs an HTTP PUT request (replace entire resource).
+
+**Example:**
+
+```typescript
+const response = await putRequest('https://api.example.com/users/1', {
+  data: {
+    name: 'Jane Doe',
+    email: 'jane@example.com',
+  },
+});
+```
+
+### `patchRequest(url, options?): Promise<APIResponse>`
+
+Performs an HTTP PATCH request (partial update).
+
+**Example:**
+
+```typescript
+const response = await patchRequest('https://api.example.com/users/1', {
+  data: { email: 'newemail@example.com' },
+});
+```
+
+### `deleteRequest(url, options?): Promise<APIResponse>`
+
+Performs an HTTP DELETE request.
+
+**Example:**
+
+```typescript
+const response = await deleteRequest('https://api.example.com/users/1');
+expect(response.status()).toBe(204); // No content
+```
+
+## Response Handling
+
+All request functions return Playwright's `APIResponse` object with the following methods:
+
+```typescript
+const response = await getRequest(url);
+
+// Status info
+response.ok(); // boolean: true if status 200-299
+response.status(); // number: HTTP status code
+
+// Body parsing
+await response.json(); // Parse body as JSON object
+await response.text(); // Parse body as plain text
+await response.body(); // Get body as Buffer
+
+// Headers
+response.headers(); // Get headers as object
+response.headersArray(); // Get headers as array of [name, value] pairs
+```
+
+## Common Patterns
+
+### Response Status Validation
+
+```typescript
+import { expect, getRequest } from '@anaconda/playwright-utils';
+
+const response = await getRequest('https://api.example.com/users/1');
+
+// Best practice: Use await expect() for async response validation
+await expect(response).toBeOK();
+
+const data = await response.json();
+expect(data).toHaveProperty('id');
+expect(data).toHaveProperty('name');
+```
+
+Alternative error handling pattern:
+
+```typescript
+const response = await getRequest('/api/users/1');
+
+if (!response.ok()) {
+  const error = await response.text();
+  throw new Error(`API error: ${response.status()} - ${error}`);
+}
+
+const data = await response.json();
+```
+
+### Authentication Headers
+
+```typescript
+const token = 'your-bearer-token';
+
+const response = await getRequest('/api/protected', {
+  headers: {
+    Authorization: `Bearer ${token}`,
+  },
+});
+```
+
+### Request Body Formats
+
+```typescript
+// JSON body (default)
+await postRequest('/api/users', {
+  data: { name: 'John', age: 30 },
+  headers: { 'Content-Type': 'application/json' },
+});
+
+// Form data
+await postRequest('/api/form', {
+  form: {
+    username: 'john',
+    password: 'secret',
+  },
+});
+
+// Multipart form (file upload)
+const fs = require('fs');
+await postRequest('/api/upload', {
+  multipart: {
+    file: fs.createReadStream('document.pdf'),
+    description: 'Important document',
+    category: 'reports',
+  },
+});
+```
+
+### Response Validation Pattern (Page Object)
+
+```typescript
+// tests/pages/api/items-api.ts
+import { expect, getRequest, logger } from '@anaconda/playwright-utils';
+
+export class ItemsAPI {
+  private readonly baseURL = 'https://api.example.com';
+
+  async verifyItemsExist(): Promise<void> {
+    const response = await getRequest(`${this.baseURL}/items`);
+    await expect(response).toBeOK();
+
+    const items = await response.json();
+    expect(Array.isArray(items), { message: 'Items response should be an array' }).toBeTruthy();
+    expect(items.length, { message: 'Items list should not be empty' }).toBeGreaterThan(0);
+    expect(items[0], { message: 'Each item should have an id field' }).toHaveProperty('id');
+    expect(items[0], { message: 'Each item should have a name field' }).toHaveProperty('name');
+
+    logger.info(`Verified ${items.length} items exist`);
+  }
+}
+```
+
+Fixture and spec:
+
+```typescript
+// tests/fixtures/fixture.ts
+import { test as base } from '@anaconda/playwright-utils';
+import { ItemsAPI } from '@pages/api/items-api';
+
+export const test = base.extend<{ itemsAPI: ItemsAPI }>({
+  itemsAPI: async ({}, use) => {
+    await use(new ItemsAPI());
+  },
+});
+
+// tests/specs/api/items-api.spec.ts
+import { test } from '@fixture';
+
+test('verify items API returns data', async ({ itemsAPI }) => {
+  await itemsAPI.verifyItemsExist();
+});
+```
+
+### Error Handling
+
+```typescript
+import { logger, postRequest } from '@anaconda/playwright-utils';
+
+const response = await postRequest('/api/users', {
+  data: { email: 'invalid' },
+});
+
+if (response.status() === 400) {
+  const errors = await response.json();
+  logger.warn(`Validation errors returned: ${JSON.stringify(errors)}`);
+}
+```
+
+## Integration with Page Objects
+
+API utils work well with page object patterns for separating API testing concerns from UI. Always use `async/await` and import from proper modules:
+
+```typescript
+// tests/pages/api/user-api.ts
+import { deleteRequest, expect, getRequest, logger, postRequest } from '@anaconda/playwright-utils';
+
+export class UserAPI {
+  private readonly baseURL = 'https://api.example.com';
+
+  async getUser(id: number) {
+    const response = await getRequest(`${this.baseURL}/users/${id}`);
+    await expect(response).toBeOK();
+    const user = await response.json();
+    logger.info(`Retrieved user: ${user.name}`);
+    return user;
+  }
+
+  async createUser(userData: Record<string, unknown>) {
+    const response = await postRequest(`${this.baseURL}/users`, {
+      data: userData,
+    });
+    expect(response.status(), { message: 'POST /users should return 201 Created' }).toBe(201);
+    const newUser = await response.json();
+    logger.info(`Created user with ID: ${newUser.id}`);
+    return newUser;
+  }
+
+  async deleteUser(id: number): Promise<void> {
+    const response = await deleteRequest(`${this.baseURL}/users/${id}`);
+    expect(response.status(), { message: `DELETE /users/${id} should return 204 No Content` }).toBe(204);
+    logger.info(`Deleted user ID: ${id}`);
+  }
+
+  async verifyUserExists(email: string) {
+    const response = await getRequest(`${this.baseURL}/users?email=${email}`);
+    await expect(response).toBeOK();
+    const users = await response.json();
+    expect(Array.isArray(users), { message: 'Users response should be an array' }).toBeTruthy();
+    expect(users.length, { message: `At least one user with email ${email} should exist` }).toBeGreaterThan(0);
+    logger.info(`Verified user exists: ${email}`);
+  }
+}
+```
+
+**Usage in specs:**
+
+```typescript
+import { test } from '@fixture';
+import { UserAPI } from '@pages/api/user-api';
+
+test.describe('User API @smoke', () => {
+  test('should create and verify user', async ({ userAPI, userPage }) => {
+    // Create user via API
+    const newUser = await userAPI.createUser({
+      name: 'John Doe',
+      email: 'john@example.com',
+    });
+
+    // Verify in UI via page object — no raw utility calls in specs
+    await userPage.verifyUserProfile(newUser.id, 'John Doe');
+
+    // Cleanup via API
+    await userAPI.deleteUser(newUser.id);
+  });
+});
+```
+
+## Sharing Cookies and Auth with Browser
+
+API requests automatically use the same request context as the browser, so cookies and authentication persist:
+
+```typescript
+// tests/pages/auth-api-page.ts
+import { clickAndNavigate, expect, fill, getRequest, gotoURL } from '@anaconda/playwright-utils';
+
+export class AuthAPIPage {
+  async loginAndVerifyProfile(): Promise<void> {
+    // Login in UI — setPage is handled automatically by the fixture
+    await gotoURL('https://example.com/login');
+    await fill('#username', 'user');
+    await fill('#password', 'pass');
+    await clickAndNavigate('#login-button');
+
+    // API requests now include auth cookies automatically
+    const response = await getRequest('https://api.example.com/profile');
+    await expect(response).toBeOK(); // Works because cookies are shared
+  }
+}
+```
+
+## Option Types
+
+Options are typed as Playwright's native API request options:
+
+```typescript
+// For getRequest
+Parameters < APIRequestContext['get'] > [1];
+
+// For postRequest
+Parameters < APIRequestContext['post'] > [1];
+
+// For putRequest
+Parameters < APIRequestContext['put'] > [1];
+
+// For patchRequest
+Parameters < APIRequestContext['patch'] > [1];
+
+// For deleteRequest
+Parameters < APIRequestContext['delete'] > [1];
+```
+
+See [Playwright APIRequestContext documentation](https://playwright.dev/docs/api/class-apirequestcontext) for complete option details including timeout, headers, auth, retry logic, and more.

--- a/tests/e2e/.claude/skills/anaconda-playwright-utils/references/assertions.md
+++ b/tests/e2e/.claude/skills/anaconda-playwright-utils/references/assertions.md
@@ -1,0 +1,478 @@
+# Assert Utils Reference
+
+Source: `src/playwright-utils/utils/assert-utils.ts`
+
+## Using Assertions in Spec Files
+
+**Do not use assertions in spec files.** Assertions are for building and verifying behaviour inside page objects (e.g. `verify*` methods). Spec files should only orchestrate steps and call those methods so the test reads like a clear, readable scenario.
+
+**Important Guidelines:**
+
+- ✅ All assertions go in page object methods (verify*, check* methods)
+- ✅ All test data goes in `tests/testdata/` folder and imported
+- ✅ Never use `console.log()` in any test file
+- ✅ If rare logging needed, use `logger` from `@anaconda/playwright-utils` in page objects only (never in specs)
+- ✅ Spec files should read like scenarios - only method calls, no raw utilities
+
+### Good Example — Readable Spec (No Assertions in Spec)
+
+The spec reads like a test plan; all assertions live in page object classes.
+
+**Spec file** — plain English, no assertion utils:
+
+```typescript
+import { test } from '@fixture';
+
+test.describe('Checkout flow @smoke', () => {
+  test.beforeEach(async ({ loginPage }) => {
+    await loginPage.navigateToLoginPage();
+    await loginPage.loginWithValidCredentials();
+  });
+
+  test('should complete full checkout flow', async ({ productsPage, cartPage, checkoutPage }) => {
+    await productsPage.verifyProductsPageIsDisplayed();
+    await productsPage.addToCartByProductNumber(1);
+    await cartPage.verifyMiniCartCount('1');
+    await checkoutPage.goToCart();
+    await checkoutPage.fillCheckoutInfo();
+    await checkoutPage.clickContinue();
+    await checkoutPage.clickFinish();
+    await checkoutPage.verifyOrderComplete();
+  });
+});
+```
+
+**Page file** — assertions live here with descriptive messages:
+
+```typescript
+// tests/pages/sauce-demo-products-page.ts
+import { expectElementToBeVisible, expectElementToBeHidden } from '@anaconda/playwright-utils';
+
+export class SauceDemoProductsPage {
+  private readonly productsContainer = '#inventory_container';
+
+  async verifyProductsPageIsDisplayed(): Promise<void> {
+    await expectElementToBeVisible(this.productsContainer, {
+      timeout: SMALL_TIMEOUT,
+      message: 'Logged in user should see Products',
+    });
+  }
+
+  async verifyProductsPageIsNotDisplayed(): Promise<void> {
+    await expectElementToBeHidden(this.productsContainer, 'Products should not be displayed');
+  }
+}
+```
+
+```typescript
+// tests/pages/sauce-demo-checkout-page.ts
+import { expectElementToContainText } from '@anaconda/playwright-utils';
+
+export class SauceDemoCheckoutPage {
+  private readonly orderCompleteMessage = '[data-test="complete-header"]';
+
+  async verifyOrderComplete(): Promise<void> {
+    await expectElementToContainText(this.orderCompleteMessage, /thank you for your order/i, {
+      message: 'Checkout complete message should be displayed',
+    });
+  }
+}
+```
+
+## Overview
+
+All assertion functions:
+
+- Accept `string | Locator` as the `input` parameter
+- Support `soft` option for soft assertions that don't stop the test
+- Support `timeout` option to override the default expect timeout
+- Support `message` option (or a string shorthand) for descriptive failure messages
+- Auto-retry until the condition is met or timeout is reached
+
+## Soft Assertions vs Hard Assertions
+
+### Hard Assertions (Default)
+
+**Use hard assertions for critical checks** — the test fails immediately when the assertion fails.
+
+```typescript
+import { test } from '@fixture';
+
+test('critical flow', async () => {
+  await expectElementToBeVisible('.critical-element', 'Critical element must be visible to proceed'); // Hard assertion — fails immediately
+  // Test stops here if assertion fails
+});
+```
+
+### Soft Assertions
+
+**Use soft assertions for non-critical checks** — the test continues even if the assertion fails, and fails at the end if any soft assertion failed. Put soft assertions inside page object `verify*` methods, just like hard assertions.
+
+```typescript
+// In the page object class:
+async verifyOptionalFeatures(): Promise<void> {
+  await expectElementToBeVisible('.optional-banner', { soft: true, message: 'Banner should display (non-critical)' });
+  await expectElementToHaveText('.secondary-message', 'Info', { soft: true, message: 'Secondary message should say Info' });
+  await expectPageToHaveURL(/dashboard/, { message: 'Should be on dashboard' });
+}
+```
+
+```typescript
+// In the spec file — call assertAllSoftAssertions after the page object method:
+import { test } from '@fixture';
+import { assertAllSoftAssertions } from '@anaconda/playwright-utils';
+
+test.describe('Dashboard optional features @reg', () => {
+  test('should display optional features', async ({ dashboardPage }) => {
+    await dashboardPage.verifyOptionalFeatures();
+    // Fail immediately after all soft checks are done (rather than at test end)
+    assertAllSoftAssertions(test.info());
+  });
+});
+```
+
+**When to use each:**
+
+- **Hard assertions** = Critical functionality (login, checkout, core features)
+- **Soft assertions** = Nice-to-have features, optional UI elements, analytics tracking
+
+## Element Assertions
+
+| Function                                          | Description                            |
+| ------------------------------------------------- | -------------------------------------- |
+| `expectElementToBeVisible(input, options?)`       | Element is in DOM and visible          |
+| `expectElementToBeHidden(input, options?)`        | Element is not in DOM or hidden        |
+| `expectElementToBeAttached(input, options?)`      | Element is in DOM (may not be visible) |
+| `expectElementToBeInViewport(input, options?)`    | Element is visible in viewport         |
+| `expectElementNotToBeInViewport(input, options?)` | Element is not in viewport             |
+| `expectElementToBeChecked(input, options?)`       | Checkbox/radio is checked              |
+| `expectElementNotToBeChecked(input, options?)`    | Checkbox/radio is not checked          |
+| `expectElementToBeDisabled(input, options?)`      | Element is disabled                    |
+| `expectElementToBeEnabled(input, options?)`       | Element is enabled                     |
+| `expectElementToBeEditable(input, options?)`      | Element is editable                    |
+
+## Text Assertions
+
+| Function                                               | Description                     |
+| ------------------------------------------------------ | ------------------------------- |
+| `expectElementToHaveText(input, text, options?)`       | Text equals value (exact match) |
+| `expectElementNotToHaveText(input, text, options?)`    | Text does NOT equal value       |
+| `expectElementToContainText(input, text, options?)`    | Text contains value (substring) |
+| `expectElementNotToContainText(input, text, options?)` | Text does NOT contain value     |
+
+`text` accepts `string | RegExp | Array<string | RegExp>`. Options extend with `ignoreCase?: boolean` and `useInnerText?: boolean`.
+
+## Value Assertions
+
+| Function                                            | Description                         |
+| --------------------------------------------------- | ----------------------------------- |
+| `expectElementToHaveValue(input, text, options?)`   | Input has the specified value       |
+| `expectElementToHaveValues(input, texts, options?)` | Multi-select has specified values   |
+| `expectElementValueToBeEmpty(input, options?)`      | Input/editable element is empty     |
+| `expectElementValueNotToBeEmpty(input, options?)`   | Input/editable element is not empty |
+
+## Attribute & Count Assertions
+
+| Function                                                        | Description                              |
+| --------------------------------------------------------------- | ---------------------------------------- |
+| `expectElementToHaveAttribute(input, attr, value, options?)`    | Attribute equals value                   |
+| `expectElementToContainAttribute(input, attr, value, options?)` | Attribute contains value                 |
+| `expectElementToHaveCount(input, count, options?)`              | Number of matching elements equals count |
+
+## Page Assertions
+
+| Function                                         | Description                       |
+| ------------------------------------------------ | --------------------------------- |
+| `expectPageToHaveURL(urlOrRegExp, options?)`     | Page URL matches exactly          |
+| `expectPageToContainURL(url, options?)`          | Page URL contains string          |
+| `expectPageToHaveTitle(titleOrRegExp, options?)` | Page title matches                |
+| `expectPageSizeToBeEqualTo(count, options?)`     | Number of open pages equals count |
+
+## Alert Assertions
+
+| Function                                        | Description                                        |
+| ----------------------------------------------- | -------------------------------------------------- |
+| `expectAlertToHaveText(input, text, options?)`  | Clicks element, asserts alert text equals value    |
+| `expectAlertToMatchText(input, text, options?)` | Clicks element, asserts alert text matches pattern |
+
+## Page Object Model Assertion Examples
+
+### Dashboard Page with Verification Methods
+
+**Page Object (tests/pages/dashboard-page.ts):**
+
+```typescript
+import {
+  expectElementToBeVisible,
+  expectElementToHaveText,
+  expectElementToHaveCount,
+  expectPageToHaveURL,
+  expectPageToHaveTitle,
+  logger,
+} from '@anaconda/playwright-utils';
+
+export class DashboardPage {
+  async verifyDashboardLoaded() {
+    // All assertions in page object, not in spec
+    await expectPageToHaveURL(/dashboard/, {
+      message: 'User should be on dashboard page',
+    });
+    await expectPageToHaveTitle('Dashboard', {
+      message: 'Page title should be Dashboard',
+    });
+    await expectElementToBeVisible('.dashboard-header', {
+      message: 'Dashboard header should be visible',
+    });
+  }
+
+  async verifyWelcomeMessage(username: string) {
+    await expectElementToHaveText('.welcome-message', `Welcome, ${username}`, {
+      message: `Welcome message should greet user as ${username}`,
+    });
+  }
+
+  async verifyUserListDisplayed() {
+    await expectElementToBeVisible('.user-list', {
+      message: 'User list should be visible',
+    });
+    const userCount = 5;
+    await expectElementToHaveCount('.user-list-item', userCount, {
+      message: `User list should have exactly ${userCount} items`,
+    });
+  }
+
+  async verifyEmptyState() {
+    await expectElementToBeVisible('.empty-state', {
+      message: 'Empty state message should be visible',
+    });
+    await expectElementToHaveText('.empty-message', 'No items found', {
+      message: 'Empty state should display correct message',
+    });
+  }
+
+  async verifyCriticalElements() {
+    // Combine multiple assertions for readability
+    await expectElementToBeVisible('.header', {
+      message: 'Header must be visible for navigation',
+    });
+    await expectElementToBeVisible('.navigation', {
+      message: 'Navigation menu must be visible',
+    });
+    await expectElementToBeVisible('.content-area', {
+      message: 'Main content area must be visible',
+    });
+  }
+
+  async verifyOptionalFeatures() {
+    // Use soft assertions for non-critical checks
+    await expectElementToBeVisible('.analytics-widget', {
+      soft: true,
+      message: 'Analytics widget should display (non-critical)',
+    });
+    await expectElementToBeVisible('.suggested-items', {
+      soft: true,
+      message: 'Suggested items should display (non-critical)',
+    });
+  }
+}
+```
+
+**Fixture (tests/fixtures/fixture.ts):**
+
+```typescript
+import { test as base } from '@anaconda/playwright-utils';
+import { DashboardPage } from '@pages/dashboard-page';
+
+export const test = base.extend({
+  dashboardPage: async ({}, use) => {
+    await use(new DashboardPage());
+  },
+});
+```
+
+**Spec File (tests/specs/dashboard.spec.ts):**
+
+```typescript
+import { test } from '@fixture';
+import { assertAllSoftAssertions } from '@anaconda/playwright-utils';
+
+test.describe('Dashboard @smoke', () => {
+  test.beforeEach(async ({ dashboardPage }) => {
+    await dashboardPage.navigateToDashboard();
+  });
+
+  test('should load dashboard correctly', async ({ dashboardPage }) => {
+    await dashboardPage.verifyDashboardLoaded();
+    await dashboardPage.verifyWelcomeMessage('John Doe');
+    await dashboardPage.verifyCriticalElements();
+  });
+
+  test('should display user list', async ({ dashboardPage }) => {
+    await dashboardPage.verifyUserListDisplayed();
+  });
+
+  test('should display optional features', async ({ dashboardPage }) => {
+    await dashboardPage.verifyOptionalFeatures();
+    assertAllSoftAssertions(test.info());
+  });
+});
+```
+
+### API Response Verification Page Object
+
+**Page Object (tests/pages/api/user-api-verifier.ts):**
+
+```typescript
+import { expect, getRequest, postRequest } from '@anaconda/playwright-utils';
+import { BASE_URL } from 'playwright.config';
+
+export class UserAPIVerifier {
+  async verifyUserExists(userId: number) {
+    const response = await getRequest(`${BASe_URL}/users/${userId}`);
+    await expect(response).toBeOK();
+
+    const user = await response.json();
+    expect(user, {
+      message: `User ${userId} should exist in API`,
+    }).toHaveProperty('id', userId);
+    expect(user, {
+      message: 'User should have name property',
+    }).toHaveProperty('name');
+    expect(user, {
+      message: 'User should have email property',
+    }).toHaveProperty('email');
+  }
+
+  async verifyUserCreated(userData: Record<string, unknown>): Promise<void> {
+    const response = await postRequest(`${this.baseURL}/users`, { data: userData });
+    expect(response.status(), {
+      message: 'POST request should return 201 Created status',
+    }).toBe(201);
+
+    const newUser = await response.json();
+    expect(newUser, {
+      message: 'Created user should have id property',
+    }).toHaveProperty('id');
+    expect(newUser.name, {
+      message: `User name should match submitted data: ${userData.name}`,
+    }).toBe(userData.name as string);
+  }
+
+  async verifyUserList() {
+    const response = await getRequest(`${this.baseURL}/users`);
+    await expect(response).toBeOK();
+
+    const users = await response.json();
+    expect(Array.isArray(users), {
+      message: 'API should return array of users',
+    }).toBeTruthy();
+    expect(users.length, {
+      message: 'User list should not be empty',
+    }).toBeGreaterThan(0);
+
+    return users;
+  }
+
+  async verifyUserNotFound(userId: number) {
+    const response = await getRequest(`${this.baseURL}/users/${userId}`);
+    expect(response.status(), {
+      message: `User ${userId} should return 404 Not Found`,
+    }).toBe(404);
+  }
+}
+```
+
+**Fixture (tests/fixtures/fixture.ts):**
+
+```typescript
+import { test as base } from '@anaconda/playwright-utils';
+import { UserAPIVerifier } from '@pages/api/user-api-verifier';
+
+export const test = base.extend({
+  userAPI: async ({}, use) => {
+    await use(new UserAPIVerifier());
+  },
+});
+```
+
+**Spec File (tests/specs/api/user-api.spec.ts):**
+
+```typescript
+import { test } from '@fixture';
+import { testUsers } from '@testdata/users';
+
+test.describe('User API @smoke', () => {
+  test('should verify user exists', async ({ userAPI }) => {
+    await userAPI.verifyUserExists(1);
+  });
+
+  test('should create a new user', async ({ userAPI }) => {
+    await userAPI.verifyUserCreated(testUsers.validUser);
+  });
+
+  test('should return user list', async ({ userAPI }) => {
+    await userAPI.verifyUserList();
+  });
+});
+```
+
+## Test Data Organization
+
+**Always store test data in `tests/testdata/` folder, not inline in spec files:**
+
+```typescript
+// ✓ GOOD: Import from testdata folder
+// tests/testdata/users.ts
+export const testUsers = {
+  validUser: { name: 'John Doe', email: 'john@example.com' },
+  adminUser: { name: 'Admin', email: 'admin@example.com' },
+};
+
+// tests/specs/api/user-api.spec.ts
+import { test } from '@fixture';
+import { testUsers } from '@testdata/users';
+
+// ✓ GOOD: Page object method returns data; spec only orchestrates, no raw assertions
+test.describe('User API @smoke', () => {
+  test('verify user created', async ({ userAPI }) => {
+    await userAPI.verifyUserCreated(testUsers.validUser);
+  });
+});
+
+// ✗ WRONG: Inline test data
+test.describe('User API @smoke', () => {
+  test('verify user created', async ({ userAPI }) => {
+    await userAPI.verifyUserCreated({
+      name: 'John Doe',
+      email: 'john@example.com',
+    });
+  });
+});
+```
+
+This keeps specs clean, reuses data across tests, and separates concerns.
+
+## Key POM Assertion Rules
+
+✓ **Do:** Put all assertions in page object methods
+✓ **Do:** Use descriptive method names like `verifyDashboardLoaded()`
+✓ **Do:** Combine related assertions into single methods for readability
+✓ **Do:** Add descriptive error messages to assertions
+✓ **Do:** Return data from verification methods if needed by tests
+✓ **Do:** Store test data in `tests/testdata/` and import it
+
+✗ **Don't:** Put assertions directly in spec files
+✗ **Don't:** Repeat assertion patterns across multiple tests
+✗ **Don't:** Mix assertions with actions without clear method names
+✗ **Don't:** Use inline test data (use testdata folder instead)
+
+## Option Types
+
+```typescript
+type ExpectOptions = TimeoutOption & SoftOption & MessageOrOptions;
+// TimeoutOption = { timeout?: number }
+// SoftOption = { soft?: boolean }
+// MessageOrOptions = string | { message?: string }
+
+type ExpectTextOptions = { ignoreCase?: boolean; useInnerText?: boolean };
+```

--- a/tests/e2e/.claude/skills/anaconda-playwright-utils/references/browser-strategy.md
+++ b/tests/e2e/.claude/skills/anaconda-playwright-utils/references/browser-strategy.md
@@ -1,0 +1,53 @@
+# Browser Strategy: Optimizing Token Usage
+
+## Three Tiers
+
+### Tier 1: Lite (WebFetch)
+
+- **Cost:** ~200-1000 tokens
+- **Use for:** Reconnaissance — page structure, navigation links, static content, checking if a page exists
+- **Tool:** `WebFetch` with the target URL
+- **Limitation:** No JavaScript execution, no interactive element refs, no form filling
+
+### Tier 2: Snapshot (playwright-cli snapshot)
+
+- **Cost:** ~500-2000 tokens per snapshot
+- **Use for:** Interactive discovery — element refs (e1, e15...), JS-rendered content, dynamic UI state
+- **Tool:** `playwright-cli open <url>` then `playwright-cli snapshot`
+- **Optimization:** Each `playwright-cli` action (click, fill, etc.) returns an automatic snapshot. Only call `snapshot` explicitly when you need a fresh view without performing an action.
+
+### Tier 3: Full Browser (playwright-cli actions)
+
+- **Cost:** ~50-200 tokens per action (requires Tier 2 first)
+- **Use for:** Selector capture — clicking, filling, navigating to verify real behavior and capture generated Playwright code
+- **Required for:** All test code generation and selector verification
+
+## Decision Rules
+
+1. **Start lite.** For any new URL, use `WebFetch` first to understand the page structure.
+2. **Recognize SPAs.** If `WebFetch` returns minimal HTML (e.g., just `<div id="root">` or `<div id="app">`), the page is JavaScript-rendered. Escalate to browser immediately.
+3. **Escalate when needed.** Switch to `playwright-cli` when you need:
+   - JavaScript-rendered content
+   - Interactive element refs (e1, e15...)
+   - Authentication-gated pages
+   - Real selector verification for test code
+4. **Stay in browser once open.** Once you've opened the browser for a URL, continue with `playwright-cli`. Don't switch back to `WebFetch` for the same page.
+5. **Minimize snapshots.** Use the automatic snapshot returned after each action. Call `playwright-cli snapshot` only when you need to re-inspect without acting.
+
+## User Overrides
+
+Users can control the strategy with natural language:
+
+| User says                                               | Effect                                               |
+| ------------------------------------------------------- | ---------------------------------------------------- |
+| "use lite mode" / "save tokens" / "quick exploration"   | Maximize `WebFetch`, only use browser when necessary |
+| "use browser mode" / "use full browser" / "be thorough" | Use `playwright-cli` for everything (skip WebFetch)  |
+| _(nothing — default)_                                   | Agents pick the right tier automatically per phase   |
+
+## Per-Agent Defaults
+
+| Agent         | Default Start Tier | Rationale                                                           |
+| ------------- | ------------------ | ------------------------------------------------------------------- |
+| **Planner**   | Tier 1 (Lite)      | Exploration-heavy; WebFetch covers initial reconnaissance           |
+| **Generator** | Tier 3 (Full)      | Must capture real selectors; browser always required                |
+| **Healer**    | Tier 1 (Lite)      | Start with error analysis + quick page check; browser for debugging |

--- a/tests/e2e/.claude/skills/anaconda-playwright-utils/references/element-utils.md
+++ b/tests/e2e/.claude/skills/anaconda-playwright-utils/references/element-utils.md
@@ -1,0 +1,383 @@
+# Element Utils Reference
+
+Source: `src/playwright-utils/utils/element-utils.ts`
+
+## Overview
+
+Element utils provide functions for retrieving data from elements and checking element states. These functions are for:
+
+- **Data extraction** — Use in variable assignments and conditionals (reading text, input values, attributes, counts)
+- **State checks** — Use in if/while statements to conditionally execute logic
+- **Wait functions** — Use for explicit synchronization when element state changes are expected
+
+**Do NOT use these for assertions** — Use `assert-utils` instead. Assertions are for test validation; these functions are for runtime data extraction and conditional logic.
+
+**Logging note:** Avoid logging in page objects. Use element-utils for data extraction only. If logging is needed in rare cases, import `logger` from `@anaconda/playwright-utils` and use it minimally at page object level (never in spec files).
+
+## Data Retrieval Functions
+
+### `getText(input, options?): Promise<string>`
+
+Returns the trimmed inner text of an element. Use for reading visible text content.
+
+```typescript
+const text = await getText('.page-title');
+// Use for data extraction and variable assignment, not logging
+
+const text2 = await getText(getLocatorByRole('heading')); // Pass Locator directly
+```
+
+### `getAllTexts(input, options?): Promise<string[]>`
+
+Returns trimmed inner text of all matching elements. Automatically waits for the first element to be attached.
+
+```typescript
+const allLabels = await getAllTexts('.form-label');
+// Use for data extraction, assignments, and conditionals
+```
+
+### `getInputValue(input, options?): Promise<string>`
+
+Returns the trimmed input value of a form element. Use for reading input field values.
+
+```typescript
+const username = await getInputValue('#username-input');
+const email = await getInputValue(getLocatorByLabel('Email'));
+```
+
+### `getAllInputValues(input, options?): Promise<string[]>`
+
+Returns input values of all matching form elements.
+
+```typescript
+const values = await getAllInputValues('input[type="checkbox"]:checked');
+```
+
+### `getAttribute(input, attributeName, options?): Promise<string | null>`
+
+Returns the trimmed attribute value, or `null` if the attribute doesn't exist.
+
+```typescript
+const ariaLabel = await getAttribute('.button', 'aria-label');
+const dataId = await getAttribute('#item-1', 'data-item-id');
+
+// Useful for conditional logic
+if (!ariaLabel) {
+  logger.warn('Button missing aria-label — consider adding one for accessibility');
+}
+```
+
+### `getLocatorCount(input, options?): Promise<number>`
+
+Returns the count of matching elements. Returns 0 on error instead of throwing.
+
+```typescript
+const itemCount = await getLocatorCount('.cart-item');
+if (itemCount === 0) {
+  logger.info('Cart is empty — no items to process');
+}
+```
+
+## Conditional Check Functions
+
+These functions return boolean values for use in conditional statements. They catch errors and return `false` instead of throwing, making them safe for use in conditionals.
+
+### `isElementAttached(input, options?): Promise<boolean>`
+
+Checks if an element is attached to the DOM. Returns `false` instead of throwing on timeout.
+
+```typescript
+if (await isElementAttached('.modal')) {
+  // Modal exists in DOM - conditional logic
+  await click('.modal .close-button');
+}
+```
+
+### `isElementVisible(input, options?): Promise<boolean>`
+
+Checks if an element is attached to the DOM and visible. Returns `false` instead of throwing.
+
+```typescript
+if (await isElementVisible('.error-message')) {
+  const errorText = await getText('.error-message');
+  // Conditional logic - use in page object methods
+}
+```
+
+### `isElementHidden(input, options?): Promise<boolean>`
+
+Checks if an element is hidden or not present in the DOM. Returns `false` instead of throwing.
+
+```typescript
+// Use in conditional logic — e.g. skip an action when element is already gone
+if (!(await isElementHidden('.loading-spinner'))) {
+  // spinner still visible — wait for it to disappear
+  await waitForElementToBeHidden('.loading-spinner');
+}
+```
+
+### `isElementChecked(input, options?): Promise<boolean>`
+
+Checks if a checkbox or radio button element is checked. Returns `false` instead of throwing.
+
+```typescript
+if (await isElementChecked('#agree-checkbox')) {
+  await click('#submit-button');
+}
+// Use for conditional logic in page object methods
+```
+
+**Usage pattern for data extraction and conditionals:**
+
+```typescript
+// Extract data based on conditions
+const itemCount = await getLocatorCount('.cart-item');
+const cartTotal = await getText('.cart-total');
+
+if (itemCount > 0) {
+  await click('.checkout-button');
+  await expectElementToBeVisible('.payment-form', {
+    message: 'Payment form should appear',
+  }); // Assert in page object
+}
+// Use conditional logic for runtime decisions
+```
+
+## Wait Functions
+
+Use these for explicit synchronization when element state changes are expected. Unlike the check functions above, these throw on timeout.
+
+### `waitForElementToBeVisible(input, options?): Promise<void>`
+
+Waits for an element to be visible. Throws on timeout.
+
+```typescript
+await waitForElementToBeVisible('.modal', { timeout: SMALL_TIMEOUT });
+// Continue execution only after modal is visible
+```
+
+### `waitForElementToBeHidden(input, options?): Promise<void>`
+
+Waits for an element to be hidden or detached from the DOM. Throws on timeout.
+
+```typescript
+// Wait for loading spinner to disappear
+await waitForElementToBeHidden('.loading-spinner', { timeout: STANDARD_TIMEOUT });
+// Now safe to interact with page
+```
+
+### `waitForElementToBeAttached(input, options?): Promise<void>`
+
+Waits for an element to be attached to the DOM. Throws on timeout.
+
+```typescript
+await waitForElementToBeAttached('.dynamic-content');
+```
+
+### `waitForElementToBeDetached(input, options?): Promise<void>`
+
+Waits for an element to be detached from the DOM (removed from HTML). Throws on timeout.
+
+```typescript
+// Modal was closed and removed from DOM
+await waitForElementToBeDetached('.modal');
+```
+
+### `waitForElementToBeStable(input, options?): Promise<boolean>`
+
+Waits for an element's position to stop changing (3 consecutive stable position checks). Returns `false` if max wait time exceeded.
+
+```typescript
+// Wait for animation to finish before clicking
+await waitForElementToBeStable('.animated-button');
+await click('.animated-button');
+```
+
+### `waitForFirstElementToBeAttached(input, options?): Promise<void>`
+
+Internal helper function — waits for the first matching element to be attached to DOM. Used internally by `getAllTexts` and `getLocatorCount`.
+
+**Usage pattern with waits (in a page object method):**
+
+```typescript
+async verifyContentLoadedAfterLoadMore(): Promise<void> {
+  await click('.load-more-button');
+
+  // Wait for loading indicator to appear and disappear
+  await waitForElementToBeVisible('.loading-spinner');
+  await waitForElementToBeHidden('.loading-spinner');
+
+  // Assert after dynamic content has loaded
+  await expectElementToBeVisible('.new-content', 'New content should appear after loading spinner hides');
+  const newItems = await getLocatorCount('.content-item');
+  expect(newItems, { message: 'At least one content item should be visible after load' }).toBeGreaterThan(0);
+}
+```
+
+## Option Types
+
+All option types are defined in `src/playwright-utils/types/optional-parameter-types.ts`:
+
+```typescript
+type TimeoutOption = {
+  timeout?: number; // Default: SMALL_TIMEOUT (5000ms)
+};
+
+type LocatorWaitOptions = TimeoutOption & {
+  waitForLocator?: boolean; // Default: true — whether to wait for first element to attach
+};
+```
+
+Import types for TypeScript:
+
+```typescript
+import { TimeoutOption, LocatorWaitOptions } from '@anaconda/playwright-utils';
+```
+
+## Wait vs Check vs Assert: Quick Reference
+
+| Function Type | Example                       | Behavior on Timeout | Use Case                                               |
+| ------------- | ----------------------------- | ------------------- | ------------------------------------------------------ |
+| **Wait**      | `waitForElementToBeVisible()` | Throws error        | Explicit synchronization when state change is expected |
+| **Check**     | `isElementVisible()`          | Returns `false`     | Conditional logic (if/while statements)                |
+| **Assert**    | `expectElementToBeVisible()`  | Fails test          | Test validation (only in page objects)                 |
+
+**Choose based on your use case:**
+
+```typescript
+// ✓ Correct: Check for conditional logic
+if (await isElementVisible('.optional-form')) {
+  await fill('.optional-form', 'data');
+}
+
+// ✓ Correct: Wait for expected state change
+await click('.toggle-button');
+await waitForElementToBeVisible('.expanded-content');
+
+// ✓ Correct: Assert in page object verify method (class-based, with message)
+async verifyContentLoaded(): Promise<void> {
+  await expectElementToBeVisible('.content', 'Content should be visible after dynamic load');
+}
+
+// ✗ Wrong: Don't use wait in conditionals (wastes time)
+if (await waitForElementToBeVisible('.optional-item')) {
+  // Slow!
+  // ...
+}
+
+// ✗ Wrong: Don't use assert in specs (should be in page objects)
+test('spec file', async () => {
+  await expectElementToBeVisible('.item'); // Move to page object!
+});
+```
+
+## Page Object Model Examples
+
+### Using Element-Utils for Data Extraction
+
+**Page Object (tests/pages/product-page.ts):**
+
+```typescript
+import {
+  // element-utils
+  getText,
+  getAllTexts,
+  getInputValue,
+  getAttribute,
+  getLocatorCount,
+  isElementVisible,
+  isElementHidden,
+  waitForElementToBeVisible,
+  // assert-utils
+  expectElementToBeVisible,
+} from '@anaconda/playwright-utils';
+
+export class ProductPage {
+  async getProductTitle(): Promise<string> {
+    return await getText('.product-title');
+  }
+
+  async getProductPrice(): Promise<string> {
+    return await getText('.product-price');
+  }
+
+  async getAllProductTitles(): Promise<string[]> {
+    return await getAllTexts('.product-item .title');
+  }
+
+  async getCartItemCount(): Promise<number> {
+    return await getLocatorCount('.cart-item');
+  }
+
+  async isProductInStock(): Promise<boolean> {
+    return await isElementVisible('.in-stock-badge');
+  }
+
+  async waitForPriceUpdateAfterDiscount(): Promise<string> {
+    await waitForElementToBeVisible('.discount-price', { timeout: SMALL_TIMEOUT });
+    return await getText('.discount-price');
+  }
+
+  async getProductDataForComparison(): Promise<{ title: string; price: string; sku: string | null; rating: string }> {
+    const title = await getText('.product-title');
+    const price = await getText('.product-price');
+    const sku = await getAttribute('.product-sku', 'value');
+    const rating = await getText('.product-rating');
+    return { title, price, sku, rating };
+  }
+
+  async getSearchResults(): Promise<string[]> {
+    const resultCount = await getLocatorCount('.search-result-item');
+    if (resultCount === 0) {
+      return [];
+    }
+    return await getAllTexts('.search-result-item');
+  }
+
+  async verifyProductDataLoaded(): Promise<void> {
+    const title = await getText('.product-title');
+    await expectElementToBeVisible('.product-title', `Product title "${title}" should be visible`);
+    await expectElementToBeVisible('.product-price', 'Product price should be visible');
+  }
+}
+```
+
+**Fixture (tests/fixtures/fixture.ts):**
+
+```typescript
+import { test as base } from '@anaconda/playwright-utils';
+import { ProductPage } from '@pages/product-page';
+
+export const test = base.extend({
+  productPage: async ({}, use) => {
+    await use(new ProductPage());
+  },
+});
+```
+
+**Spec File (tests/specs/product.spec.ts):**
+
+```typescript
+import { test } from '@fixture';
+
+test('verify product page is loaded', async ({ productPage }) => {
+  // All assertions are inside the page object verify method
+  await productPage.verifyProductDataLoaded();
+});
+
+test('wait for dynamic price update', async ({ productPage }) => {
+  // Page object handles wait + extraction internally
+  await productPage.waitForPriceUpdateAfterDiscount();
+});
+```
+
+## Summary: Element-Utils Usage in POM
+
+| Purpose               | Use In              | Example                                          |
+| --------------------- | ------------------- | ------------------------------------------------ |
+| **Data extraction**   | Page object methods | `getText()`, `getAllTexts()`, `getAttribute()`   |
+| **Get counts**        | Page object methods | `getLocatorCount()` to verify list sizes         |
+| **Conditional logic** | Page object methods | `isElementVisible()` to handle optional elements |
+| **Wait for changes**  | Page object methods | `waitForElementToBeVisible()` to sync state      |
+| **Assertions**        | Page object methods | Result of `getText()` in expectation             |
+| **Spec files**        | Never directly      | Only call page object methods                    |

--- a/tests/e2e/.claude/skills/anaconda-playwright-utils/references/locators.md
+++ b/tests/e2e/.claude/skills/anaconda-playwright-utils/references/locators.md
@@ -1,0 +1,304 @@
+# Locator Utils Reference
+
+Source: `src/playwright-utils/utils/locator-utils.ts`
+
+## Locator Strategy Priority
+
+When choosing locators for test code, follow this priority order (best to worst). **Prefer unique CSS or XPath with stable attributes over text-based locators** so that when a check fails you can tell quickly whether the element is missing (bug) or the copy changed (new functionality / locale).
+
+> **Mandatory upgrade rule:** If a DOM snapshot or page inspection reveals a `data-qa-id` or any `data-*` attribute on an element, use it. Never keep a role- or text-based locator when a stable attribute exists — even if the CLI generated one.
+
+### 1. `data-qa-id` attributes (Best)
+
+Purpose-built for testing by QA and developers. Never changes due to styling or refactoring.
+
+```typescript
+// HTML: <button data-qa-id="submit-order">Place Order</button>
+await click(getLocatorByTestId('submit-order'));
+
+// HTML: <input data-qa-id="email-input">
+await fill(getLocatorByTestId('email-input'), userData.email);
+```
+
+### 2. `data-testid` and other `data-*` attributes
+
+`data-testid` is Playwright's default `testIdAttribute`. Use `getLocatorByTestId()` for it just like `data-qa-id`. For other custom `data-*` attributes that are not the configured `testIdAttribute`, use a CSS selector.
+
+```typescript
+// HTML: <button data-testid="submit-order">Place Order</button>
+await click(getLocatorByTestId('submit-order')); // ✅ getLocatorByTestId for data-testid
+
+// HTML: <div data-product-id="shoes-001">...</div>
+await click('[data-product-id="shoes-001"]'); // ✅ CSS for non-testId data-* attributes
+
+// HTML: <h2 data-test="complete-header">Thank you for your order</h2>
+const orderCompleteMessage = () => getLocator('[data-test="complete-header"]');
+await expectElementToContainText(orderCompleteMessage(), /thank you for your order/i, {
+  message: 'Checkout complete message should be displayed',
+});
+```
+
+### 3. `id` attributes
+
+Stable when IDs are meaningful and developer-controlled. Avoid auto-generated IDs.
+
+```typescript
+// Good: semantic ID
+await fill('#search-input', 'playwright');
+
+// Bad: auto-generated ID (changes every render)
+// await fill('#input-7f3a2b', 'playwright');  // DON'T use this
+```
+
+### 4. `name` attributes
+
+Reliable for form elements. Often stable across releases.
+
+```typescript
+// HTML: <input name="email" type="email">
+await fill('[name="email"]', userData.email);
+
+// HTML: <select name="country">...</select>
+await selectByText('[name="country"]', 'United States');
+```
+
+### 5. XPath with unique attributes
+
+Use when no data-_ or id is available. Target **stable attributes** (e.g. `data-test`, `aria-_`, `type`), not text.
+
+```typescript
+// Good: XPath with stable attributes
+await click('//button[@aria-label="Close dialog"]');
+await click('//input[@type="email"]');
+
+// Good: ancestor scoping with stable attributes
+await click('//div[@data-section="billing"]//button[@type="submit"]');
+```
+
+### 6. CSS with unique attributes
+
+Use stable attribute selectors so the locator does not depend on copy or locale.
+
+```typescript
+// Good: attribute-based CSS
+await click('button[aria-label="Close dialog"]');
+await fill('input[type="email"]', userData.email);
+
+// Good: scoped by stable parent
+await click('.billing-section button[type="submit"]');
+
+// Good: data-test (e.g. Sauce Demo checkout complete)
+const orderCompleteMessage = () => getLocator('[data-test="complete-header"]');
+await expectElementToContainText(orderCompleteMessage(), /thank you for your order/i);
+```
+
+### 7. Playwright built-in locators (role / text) — use only when no stable selector exists
+
+Text- and role-based locators are **flaky**: they change with copy, locale, and country. If the only way to find an element is by its text, a failure does not tell you whether the element is missing (bug) or the wording changed (new feature / i18n). Prefer **data-qa-id**, **data-testid**, **data-\***, **id**, or **unique CSS/XPath** first.
+
+When you must use role or text:
+
+```typescript
+// By ARIA role + accessible name
+await click(getLocatorByRole('button', { name: 'Submit' }));
+await fill(getLocatorByRole('textbox', { name: 'Email' }), userData.email);
+
+// By label text (form fields)
+await fill(getLocatorByLabel('Email address'), userData.email);
+
+// By placeholder text
+await fill(getLocatorByPlaceholder('Search...'), serachData.query);
+
+// By visible text — avoid for assertions; use stable selector + assert text separately
+await click(getLocatorByText('Add to cart'));
+```
+
+**Assertions:** Prefer a **stable locator** for the element and assert the **text in the assertion**. That way a failure shows "expected text X, got Y" (copy change) vs element not found (bug).
+
+```typescript
+// Prefer: stable selector + text in assertion
+const orderCompleteMessage = () => getLocator('[data-test="complete-header"]');
+await expectElementToContainText(orderCompleteMessage(), /thank you for your order/i);
+
+// Avoid: locating by text — fails ambiguously if copy or locale changes
+// const orderCompleteMessage = () => getLocatorByRole('heading', { name: /thank you for your order/i });
+```
+
+### 8. XPath (structural)
+
+Positional XPath. Fragile — use as last resort.
+
+```typescript
+// Fragile: depends on DOM structure
+await click('//div[@class="form-group"][2]//button');
+```
+
+### 9. CSS (structural)
+
+Positional CSS. Equally fragile.
+
+```typescript
+// Fragile: depends on DOM order
+await click('.form-group:nth-child(2) button');
+```
+
+### What to Avoid
+
+Locators that rely on values likely to change between runs:
+
+```typescript
+// DON'T: auto-generated IDs
+await click('#ember-1234');
+await click('#react-select-3-option-0');
+
+// DON'T: dynamic index numbers or counts
+await click('//tr[42]/td[3]/button');
+
+// DON'T: timestamp or session-dependent values
+await click('[data-id="item-1710612345"]');
+
+// DON'T: deeply nested structural paths
+await click('div > div > div > ul > li:nth-child(3) > a');
+
+// DON'T: class names from CSS frameworks (change on rebuild)
+await click('.css-1a2b3c');
+await click('.MuiButton-root-123');
+```
+
+## Key Concept: Visible by Default
+
+`getVisibleLocator()` (and by extension all action functions) filters to only visible elements by default. This prevents accidentally interacting with hidden duplicates.
+
+```typescript
+// Returns locator filtered to visible elements
+const loc = getVisibleLocator('#submit');
+
+// Equivalent to:
+const loc = getLocator('#submit', { onlyVisible: true });
+
+// To include hidden elements:
+const loc = getLocator('#submit', { onlyVisible: false });
+```
+
+## When Multiple Elements Match
+
+All action functions enforce `onlyVisible: true` internally, so hidden duplicates are already filtered at call time. If multiple elements **still** match after that, the fix is a **more specific locator** — not a visibility wrapper and not an index.
+
+**Step 1 — look for a unique attribute on the target or a stable ancestor, then scope:**
+
+```typescript
+// ❌ Never — index breaks silently when the page changes
+private readonly pendingButton = () => getLocatorByText('Pending').nth(2);
+
+// ✅ Simple 1-level scoping — prefer getLocatorByTestId chaining
+private readonly channelItem = () =>
+  getLocatorByTestId('channel-list').locator('[data-qa-id="channel-item"]');
+
+// ✅ Complex scoping (2+ ancestor levels or mixed locator types) — CSS compound is preferred
+private readonly pendingButton = '[data-qa-id="channel-list"] [data-qa-id="pending-btn"]';
+
+// ✅ XPath ancestor scope (stable attribute on row + aria-label on button)
+private readonly pendingButton = '//tr[@data-qa-id="latest-row"]//button[@aria-label="Pending"]';
+```
+
+**When to use CSS compound vs `getLocatorByTestId` chaining:**
+
+- **Single element** — always `getLocatorByTestId()`: `private readonly x = () => getLocatorByTestId('x')`
+- **1-level ancestor scope** — `getLocatorByTestId` chaining is preferred: `getLocatorByTestId('parent').locator('[data-qa-id="child"]')`
+- **2+ ancestor levels or mixed types** — CSS compound is preferred over deeply nested chains:
+
+```typescript
+// ❌ Over-engineered — hard to read
+private readonly pendingButton = () =>
+  getLocatorByTestId('dashboard')
+    .locator(getLocatorByTestId('channel-list').locator('[data-qa-id="pending-btn"]'));
+
+// ✅ CSS compound — flat, readable, and maintainable
+private readonly pendingButton = '[data-qa-id="channel-list"] [data-qa-id="pending-btn"]';
+```
+
+**Step 2 — if no stable attribute exists on the target, write a custom XPath using structural context + stable ancestor attributes:**
+
+```typescript
+// ✅ XPath scoped by nearest ancestor with a stable attribute
+private readonly submitButton = '//div[@id="billing-section"]//button[@type="submit"]';
+```
+
+**`.nth()` / `.first()` / `.last()` are last resort only.** If you must use one, add a comment explaining why no unique locator was possible — it is a signal to revisit when the element gains a stable attribute.
+
+## Locator Functions
+
+### `getLocator(input: string | Locator, options?: LocatorOptions): Locator`
+
+Core function. If `input` is a string, creates a locator via `page.locator(input)`. If `input` is already a Locator, returns it as-is. When `onlyVisible: true`, appends `visible=true` filter.
+
+### `getVisibleLocator(input: string | Locator, options?: LocatorOptions): Locator`
+
+Same as `getLocator` but defaults to `onlyVisible: true`. This is what action functions use internally.
+
+### `getLocatorByTestId(testId: string | RegExp): Locator`
+
+Uses `page.getByTestId()`. The test ID attribute is configured in `playwright.config.ts` (defaults to `data-testid`).
+
+### `getLocatorByText(text: string | RegExp, options?: GetByTextOptions): Locator`
+
+Uses `page.getByText()`. Finds elements by their text content.
+
+### `getLocatorByRole(role: GetByRoleTypes, options?: GetByRoleOptions): Locator`
+
+Uses `page.getByRole()`. Finds elements by ARIA role.
+
+```typescript
+const btn = getLocatorByRole('button', { name: 'Submit' });
+const link = getLocatorByRole('link', { name: /learn more/i });
+```
+
+### `getLocatorByLabel(text: string | RegExp, options?: GetByRoleOptions): Locator`
+
+Uses `page.getByLabel()`. Finds form elements by their associated label.
+
+### `getLocatorByPlaceholder(text: string | RegExp, options?: GetByPlaceholderOptions): Locator`
+
+Uses `page.getByPlaceholder()`. Finds input elements by placeholder text.
+
+### `getAllLocators(input: string | Locator, options?): Promise<Locator[]>`
+
+Returns all matching locators as an array. Waits for at least the first element to be attached before resolving.
+
+Options include `waitForLocator?: boolean` (default `true`) and `timeout?: number`.
+
+## Frame Functions
+
+### `getFrame(frameSelector: FrameOptions, options?): Frame | null`
+
+Gets a Frame by name or URL. Throws if not found unless `{ force: true }`.
+
+```typescript
+const frame = getFrame({ name: 'my-iframe' });
+const frame = getFrame({ url: /embed/ });
+```
+
+### `getFrameLocator(frameInput: string | FrameLocator): FrameLocator`
+
+Gets a FrameLocator from a selector or existing FrameLocator.
+
+### `getLocatorInFrame(frameInput, input): Locator`
+
+Gets a locator for an element inside a frame.
+
+```typescript
+const btn = getLocatorInFrame('#my-iframe', '#submit-btn');
+await click(btn); // Works with action utils
+```
+
+## Option Types
+
+```typescript
+type LocatorOptions = PlaywrightLocatorOptions & { onlyVisible?: boolean };
+type LocatorWaitOptions = { waitForLocator?: boolean } & TimeoutOption;
+type GetByTextOptions = PlaywrightGetByTextOptions & { onlyVisible?: boolean };
+type GetByRoleTypes = PlaywrightGetByRoleTypes & { onlyVisible?: boolean };
+type GetByRoleOptions = PlaywrightGetByRoleOptions & { onlyVisible?: boolean };
+type GetByPlaceholderOptions = PlaywrightGetByPlaceholderOptions & { onlyVisible?: boolean };
+type FrameOptions = PlaywrightFrameOptions; // { name?: string, url?: string | RegExp }
+```

--- a/tests/e2e/.claude/skills/anaconda-playwright-utils/references/page-utils.md
+++ b/tests/e2e/.claude/skills/anaconda-playwright-utils/references/page-utils.md
@@ -1,0 +1,555 @@
+# Page Utils Reference
+
+Source: `src/playwright-utils/utils/page-utils.ts`
+
+## Overview
+
+Page utils provide functions for page management, navigation, and multi-tab handling. All functions work with the library's singleton page pattern — they internally call `getPage()` to access the current page instance, so you don't need to pass `page` to every function call.
+
+## Page Instance Management
+
+### `getPage(): Page`
+
+Returns the current `Page` instance (singleton). This is called internally by all utility functions.
+
+**Usage:**
+
+```typescript
+const page = getPage();
+// Use only for advanced Playwright API access when utility functions don't cover your use case
+```
+
+### `setPage(pageInstance: Page): void`
+
+Sets the current `Page` instance. **Automatically called by the fixture before each test — you don't need to use this directly.**
+
+**Always use the fixture pattern:**
+
+```typescript
+import { test } from '@fixture'; // Automatically calls setPage(page) before each test
+import { urlData } from '@testdata/urls-testdata'; // imports url data
+
+test('example', async () => {
+  // setPage() already called by fixture - just use the utilities
+  await gotoURL(urlData.homePageUrl);
+  await click('#button');
+  await expectPageToHaveURL(/example/, { message: 'Should remain on the example domain after clicking button' });
+});
+```
+
+**Do NOT manually call `setPage()`** — The fixture handles page setup automatically for all tests.
+
+### `getContext(): BrowserContext`
+
+Returns the browser context associated with the current page.
+
+**Usage:**
+
+```typescript
+const context = getContext();
+const cookies = await context.cookies();
+const pages = await context.pages();
+```
+
+### Singleton Pattern Explanation
+
+The library maintains a module-level `page` variable. This design eliminates the need to pass `page` to every function. The fixture handles page setup automatically:
+
+**Standard Playwright (pass page to every function):**
+
+```typescript
+await page.goto(url);
+await page.locator(sel).click();
+await expect(page.locator(sel)).toBeVisible();
+```
+
+**With anaconda-playwright-utils + fixture (no setPage needed):**
+
+```typescript
+// Fixture calls setPage(page) automatically
+await gotoURL(url);
+await click(sel);
+await expectElementToBeVisible(sel, 'Element should be visible after action');
+```
+
+This makes test code cleaner, easier to read, and eliminates the need for manual page setup.
+
+## Multi-Tab Management
+
+### `getAllPages(): Page[]`
+
+Returns an array of all pages (tabs) in the current browser context.
+
+**Example:**
+
+```typescript
+const pages = getAllPages();
+logger.info(`Total tabs open: ${pages.length}`);
+```
+
+### `switchPage(winNum: number, options?): Promise<void>`
+
+Switches to a different page (tab) by its **1-based index** and makes it the current page.
+
+**Parameters:**
+
+- `winNum` — 1-based index (1 = first tab, 2 = second tab, etc.)
+- `options.loadState` — Load state to wait for after switching (default: `'load'`)
+
+**Important:** Always use 1-based indexing, not 0-based.
+
+**Example:**
+
+```typescript
+// User action opens a new tab (second tab created)
+await click('a[target="_blank"]');
+
+// Switch to the new tab (index 2)
+await switchPage(2);
+
+// Now all utility functions work on the new tab
+await expectPageToHaveURL(/new-page/, { message: 'Should have navigated to new page in second tab' });
+await click('#content-button');
+
+// Switch back to the first tab
+await switchPage(1);
+```
+
+### `switchToDefaultPage(): Promise<void>`
+
+Switches back to the first page (index 1). Convenience function equivalent to `switchPage(1)`.
+
+**Example:**
+
+```typescript
+// After working on multiple tabs, return to the original
+await switchToDefaultPage();
+```
+
+### `closePage(winNum?: number): Promise<void>`
+
+Closes a page (tab) by its 1-based index. If no index is provided, closes the current page.
+
+**Parameters:**
+
+- `winNum` — Optional 1-based index. If omitted, closes the current page.
+
+**Example:**
+
+```typescript
+// Close the second tab
+await closePage(2);
+
+// Close the current tab
+await closePage();
+```
+
+**Important:** After closing a page, the library automatically switches to the default page (index 1) if there are remaining pages. Call `switchPage()` explicitly only if you need to land on a specific tab.
+
+## Navigation Functions
+
+### `gotoURL(path: string, options?): Promise<Response | null>`
+
+Navigates to the specified URL. Waits for the default load state before returning.
+
+**Parameters:**
+
+- `path` — URL or path to navigate to
+- `options.timeout` — Navigation timeout (default: NAVIGATION_TIMEOUT)
+- `options.waitUntil` — Load state to wait for: `'load'` | `'domcontentloaded'` | `'networkidle'` | `'commit'`
+- `options.referer` — Referer header value
+
+**Example:**
+
+```typescript
+await gotoURL(urlData.exampleUrl);
+await gotoURL(urlData.exampleUrl, { waitUntil: 'networkidle' });
+await gotoURL('/relative/path'); // Relative to base URL
+```
+
+### `getURL(options?): Promise<string>`
+
+Returns the current page URL. Optionally waits for a load state first.
+
+**Example:**
+
+```typescript
+const currentURL = await getURL();
+
+// Wait for network idle before getting URL (useful after navigation)
+const finalURL = await getURL({ waitUntil: 'networkidle' });
+```
+
+### `waitForPageLoadState(options?): Promise<void>`
+
+Waits for a specific page load state.
+
+**Parameters:**
+
+- `options.waitUntil` — Load state to wait for (default: from constants)
+- `options.timeout` — Wait timeout
+
+**Example:**
+
+```typescript
+// Wait for all network requests to complete
+await waitForPageLoadState({ waitUntil: 'networkidle' });
+
+// Wait for DOM to be interactive
+await waitForPageLoadState({ waitUntil: 'domcontentloaded' });
+```
+
+### `reloadPage(options?): Promise<void>`
+
+Reloads the current page.
+
+**Example:**
+
+```typescript
+await reloadPage();
+await reloadPage({ waitUntil: 'domcontentloaded' });
+```
+
+### `goBack(options?): Promise<void>`
+
+Navigates to the previous page in browser history.
+
+**Example:**
+
+```typescript
+// Use goBack() directly for browser history navigation:
+await goBack();
+```
+
+## Utility Functions
+
+### `wait(ms: number): Promise<void>`
+
+Waits for a specified number of milliseconds. Use sparingly — prefer explicit waits for specific conditions.
+
+**Example:**
+
+```typescript
+await wait(1000); // Wait 1 second
+```
+
+**Better alternatives:**
+
+```typescript
+// Instead of arbitrary wait(), use explicit waits
+await waitForElementToBeVisible('.modal'); // Wait for visibility
+await waitForPageLoadState(); // Wait for page load
+await expectElementToBeVisible('.content', 'Content should be visible after page load'); // Assert with auto-retry
+```
+
+### `getWindowSize(): Promise<{ width: number; height: number }>`
+
+Returns the current browser window size in pixels.
+
+**Example:**
+
+```typescript
+const { width, height } = await getWindowSize();
+
+if (width < 768) {
+  // Handle mobile viewport
+}
+```
+
+### `saveStorageState(path?: string): Promise<StorageState>`
+
+Saves the current browser storage state (cookies, localStorage, sessionStorage) to a file. Returns the storage state object.
+
+**Parameters:**
+
+- `path` — Optional file path. If provided, saves to file. If omitted, returns state without saving.
+
+**Returns:** Storage state object with structure:
+
+```typescript
+{
+  cookies: Array<{ name, value, domain, path, ... }>,
+  origins: Array<{ origin, localStorage: Array<{ name, value }>, ... }>
+}
+```
+
+**Example:**
+
+```typescript
+// Save to file
+await saveStorageState('./auth-state.json');
+
+// Get state without saving
+const state = await saveStorageState();
+logger.info(`Cookies captured: ${state.cookies?.length ?? 0}`);
+```
+
+**Usage with authentication (save auth state for reuse):**
+
+```typescript
+import { test } from '@fixture';
+import { gotoURL, fill, clickAndNavigate, saveStorageState } from '@anaconda/playwright-utils';
+import { urlData } from '@testdata/urls-testdata';
+import { userData } from '@testdata/user-testdata';
+
+// tests/auth.setup.ts — Run once to save auth state
+test('authenticate and save state', async () => {
+  // setPage() called automatically by fixture
+  await gotoURL(urlData.loginPageUrl);
+  await fill('#username', userData.userName);
+  await fill('#password', userData.pwd);
+  await clickAndNavigate('#login-button');
+
+  // Save auth state
+  await saveStorageState('./.auth/user-auth.json');
+});
+
+// playwright.config.ts — Reuse auth state in other tests
+{
+  name: 'authenticated',
+  use: { storageState: './.auth/user-auth.json' },
+}
+
+// tests/specs/dashboard.spec.ts — Uses saved auth automatically
+import { test } from '@fixture';
+
+test('view dashboard', async ({ dashboardPage }) => {
+  // Already authenticated because storageState is loaded
+  await dashboardPage.verifyDashboardLoaded();
+});
+```
+
+## Multi-Tab Workflow Example (Page Object Model)
+
+**Page Object (tests/pages/dashboard-page.ts):**
+
+```typescript
+import {
+  gotoURL,
+  click,
+  switchPage,
+  closePage,
+  switchToDefaultPage,
+  expectPageToHaveURL,
+  expectElementToBeVisible,
+  getText,
+  fill,
+} from '@anaconda/playwright-utils';
+import { urlData } from '@testdata/urls-testdata';
+import { reviewData } from '@testdata/product-review-testdata';
+
+export class DashboardPage {
+  async navigateToDashboard() {
+    await gotoURL(urlData.homePageUrl);
+    await expectElementToBeVisible('.dashboard', {
+      message: 'Dashboard should be visible after navigation',
+    });
+  }
+
+  async openProductInNewTab() {
+    await click('a[target="_blank"]');
+    await switchPage(2); // Switch to new tab
+  }
+
+  async verifyProductPageLoaded() {
+    await expectPageToHaveURL(/product-2/, {
+      message: 'Product page should be loaded when switching to tab 2',
+    });
+    await expectElementToBeVisible('.product-page', {
+      message: 'Product page content should be visible',
+    });
+  }
+
+  async getProductDetails() {
+    const itemId = await getText('.item-id');
+    const price = await getText('.price');
+    return { itemId, price };
+  }
+
+  async submitProductReview(comment: string) {
+    await fill('#comment', comment);
+    await click('#submit-button');
+    await expectElementToBeVisible('.success-message', {
+      message: 'Success message should appear after submitting review',
+    });
+  }
+
+  async closeProductTab() {
+    await closePage(2);
+  }
+
+  async returnToDashboard() {
+    await switchToDefaultPage();
+    await expectPageToHaveURL('https://example.com', {
+      message: 'Should return to dashboard (tab 1) with correct URL',
+    });
+    await expectElementToBeVisible('.dashboard', {
+      message: 'Dashboard should be visible when returning to tab 1',
+    });
+  }
+
+  async comparePricesInMultipleTabs() {
+    await this.navigateToDashboard();
+    await this.openProductInNewTab();
+    await this.verifyProductPageLoaded();
+    const details = await this.getProductDetails();
+    await this.submitProductReview(reviewData.review);
+    await this.closeProductTab();
+    await this.returnToDashboard();
+    return details;
+  }
+}
+```
+
+**Fixture (tests/fixtures/fixture.ts):**
+
+```typescript
+import { test as base } from '@anaconda/playwright-utils';
+import { DashboardPage } from '@pages/dashboard-page';
+
+export const test = base.extend({
+  dashboardPage: async ({}, use) => {
+    await use(new DashboardPage());
+  },
+});
+```
+
+**Spec File (tests/specs/multi-tab.spec.ts):**
+
+```typescript
+import { test } from '@fixture';
+import { reviewData } from '@testdata/product-review-testdata';
+
+test.describe('Multi-tab product workflow @reg', () => {
+  test.beforeEach(async ({ dashboardPage }) => {
+    await dashboardPage.navigateToDashboard();
+  });
+
+  test('should compare prices across tabs', async ({ dashboardPage }) => {
+    await dashboardPage.comparePricesInMultipleTabs();
+  });
+
+  test('should view product and leave review', async ({ dashboardPage }) => {
+    await dashboardPage.openProductInNewTab();
+    await dashboardPage.verifyProductPageLoaded();
+    await dashboardPage.submitProductReview(reviewData.review);
+    await dashboardPage.closeProductTab();
+    await dashboardPage.returnToDashboard();
+  });
+});
+```
+
+**Key POM Benefits:**
+
+- ✓ Spec file is clean and readable (just method calls)
+- ✓ All implementation details in page object
+- ✓ Easy to reuse methods across multiple tests
+- ✓ Easier to maintain (change logic once, affects all tests)
+- ✓ Methods can be composed (like `comparePricesInMultipleTabs()`)
+- ✓ Logging is centralized and consistent
+
+## Option Types
+
+```typescript
+type GotoOptions = {
+  timeout?: number;
+  waitUntil?: 'load' | 'domcontentloaded' | 'networkidle' | 'commit';
+  referer?: string;
+};
+
+type NavigationOptions = {
+  timeout?: number;
+  waitUntil?: 'load' | 'domcontentloaded' | 'networkidle' | 'commit';
+};
+
+type SwitchPageOptions = {
+  loadState?: WaitForLoadStateOptions; // Default: 'load'
+};
+```
+
+## Common Patterns
+
+### Navigation vs Same-Page Interactions
+
+Use `clickAndNavigate()` when a click triggers a full page navigation. Use `click()` for same-page interactions only. Never add waiting conditions after either.
+
+```typescript
+// clickAndNavigate: handles framenavigated + load state + element staleness automatically
+await clickAndNavigate('#submit-button'); // form submit → new page
+await clickAndNavigate(getLocatorByRole('link', { name: 'Dashboard' })); // nav link
+
+// click(): same-page interactions only — no navigation, no explicit waits after
+await click('#dropdown-toggle'); // opens dropdown
+await click(getLocatorByRole('tab', { name: 'Settings' })); // switches tab (AJAX)
+```
+
+### Handle Multiple Tabs in Workflow
+
+```typescript
+export class ComparisonPage {
+  async comparePrices() {
+    // Tab 1: Get first product price
+    await gotoURL(urlData.productPageUrl);
+    const price1 = await getText('.price');
+
+    // Open second tab
+    await click('a[target="_blank"]');
+    await switchPage(2);
+
+    // Tab 2: Get second product price
+    await expectPageToHaveURL(/product-2/, {
+      message: 'Second product page should load in tab 2',
+    });
+    const price2 = await getText('.price');
+
+    // Compare
+    const isCheaper = parseInt(price1) < parseInt(price2);
+
+    // Cleanup
+    await closePage(2);
+    await switchToDefaultPage();
+
+    return { price1, price2, isCheaper };
+  }
+}
+```
+
+### Save and Restore Authentication
+
+Auth setup is done in a dedicated setup spec that runs once. All other tests then consume the saved state via `playwright.config.ts`.
+
+```typescript
+// tests/storage-setup/auth.setup.ts — runs once to capture auth state
+import { test } from '@fixture'; // fixture auto-calls setPage(page)
+import { gotoURL, fill, clickAndNavigate, saveStorageState } from '@anaconda/playwright-utils';
+import { urlData } from '@testdata/urls-testdata';
+import { userData } from '@testdata/user-testdata';
+
+test('authenticate and save state', async () => {
+  await gotoURL(urlData.loginPageUrl);
+  await fill('#username', userData.userName);
+  await fill('#password', userData.pwd);
+  await clickAndNavigate('#login-button');
+  await saveStorageState('./.auth/user-auth.json');
+});
+```
+
+```typescript
+// playwright.config.ts — apply saved state to all authenticated tests
+{
+  name: 'authenticated',
+  use: { storageState: './.auth/user-auth.json' },
+  dependencies: ['setup'],
+}
+```
+
+```typescript
+// tests/specs/protected.spec.ts — already authenticated, no login needed
+import { test } from '@fixture';
+
+test.describe('Protected pages @smoke', () => {
+  test('should access protected content', async ({ protectedPage }) => {
+    await protectedPage.verifyProtectedContentIsDisplayed();
+  });
+});
+```

--- a/tests/e2e/.claude/skills/playwright-cli/SKILL.md
+++ b/tests/e2e/.claude/skills/playwright-cli/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: playwright-cli
+description: Automates browser interactions for web testing, form filling, screenshots, and data extraction. Use when the user needs to navigate websites, interact with web pages, fill forms, take screenshots, test web applications, or extract information from web pages.
+allowed-tools: Bash(playwright-cli:*)
+---
+
+# Browser Automation with playwright-cli
+
+## Quick start
+
+```bash
+# open new browser
+playwright-cli open
+# navigate to a page
+playwright-cli goto https://playwright.dev
+# interact with the page using refs from the snapshot
+playwright-cli click e15
+playwright-cli type "page.click"
+playwright-cli press Enter
+# take a screenshot (rarely used, as snapshot is more common)
+playwright-cli screenshot
+# close the browser
+playwright-cli close
+```
+
+## Commands
+
+### Core
+
+```bash
+playwright-cli open
+# open and navigate right away
+playwright-cli open https://example.com/
+playwright-cli goto https://playwright.dev
+playwright-cli type "search query"
+playwright-cli click e3
+playwright-cli dblclick e7
+playwright-cli fill e5 "user@example.com"
+playwright-cli drag e2 e8
+playwright-cli hover e4
+playwright-cli select e9 "option-value"
+playwright-cli upload ./document.pdf
+playwright-cli check e12
+playwright-cli uncheck e12
+playwright-cli snapshot
+playwright-cli snapshot --filename=after-click.yaml
+playwright-cli eval "document.title"
+playwright-cli eval "el => el.textContent" e5
+playwright-cli dialog-accept
+playwright-cli dialog-accept "confirmation text"
+playwright-cli dialog-dismiss
+playwright-cli resize 1920 1080
+playwright-cli close
+```
+
+### Navigation
+
+```bash
+playwright-cli go-back
+playwright-cli go-forward
+playwright-cli reload
+```
+
+### Keyboard
+
+```bash
+playwright-cli press Enter
+playwright-cli press ArrowDown
+playwright-cli keydown Shift
+playwright-cli keyup Shift
+```
+
+### Mouse
+
+```bash
+playwright-cli mousemove 150 300
+playwright-cli mousedown
+playwright-cli mousedown right
+playwright-cli mouseup
+playwright-cli mouseup right
+playwright-cli mousewheel 0 100
+```
+
+### Save as
+
+```bash
+playwright-cli screenshot
+playwright-cli screenshot e5
+playwright-cli screenshot --filename=page.png
+playwright-cli pdf --filename=page.pdf
+```
+
+### Tabs
+
+```bash
+playwright-cli tab-list
+playwright-cli tab-new
+playwright-cli tab-new https://example.com/page
+playwright-cli tab-close
+playwright-cli tab-close 2
+playwright-cli tab-select 0
+```
+
+### Storage
+
+```bash
+playwright-cli state-save
+playwright-cli state-save auth.json
+playwright-cli state-load auth.json
+
+# Cookies
+playwright-cli cookie-list
+playwright-cli cookie-list --domain=example.com
+playwright-cli cookie-get session_id
+playwright-cli cookie-set session_id abc123
+playwright-cli cookie-set session_id abc123 --domain=example.com --httpOnly --secure
+playwright-cli cookie-delete session_id
+playwright-cli cookie-clear
+
+# LocalStorage
+playwright-cli localstorage-list
+playwright-cli localstorage-get theme
+playwright-cli localstorage-set theme dark
+playwright-cli localstorage-delete theme
+playwright-cli localstorage-clear
+
+# SessionStorage
+playwright-cli sessionstorage-list
+playwright-cli sessionstorage-get step
+playwright-cli sessionstorage-set step 3
+playwright-cli sessionstorage-delete step
+playwright-cli sessionstorage-clear
+```
+
+### Network
+
+```bash
+playwright-cli route "**/*.jpg" --status=404
+playwright-cli route "https://api.example.com/**" --body='{"mock": true}'
+playwright-cli route-list
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+### DevTools
+
+```bash
+playwright-cli console
+playwright-cli console warning
+playwright-cli network
+playwright-cli run-code "async page => await page.context().grantPermissions(['geolocation'])"
+playwright-cli tracing-start
+playwright-cli tracing-stop
+playwright-cli video-start
+playwright-cli video-stop video.webm
+```
+
+## Open parameters
+
+```bash
+# Use specific browser when creating session
+playwright-cli open --browser=chrome
+playwright-cli open --browser=firefox
+playwright-cli open --browser=webkit
+playwright-cli open --browser=msedge
+# Connect to browser via extension
+playwright-cli open --extension
+
+# Use persistent profile (by default profile is in-memory)
+playwright-cli open --persistent
+# Use persistent profile with custom directory
+playwright-cli open --profile=/path/to/profile
+
+# Start with config file
+playwright-cli open --config=my-config.json
+
+# Close the browser
+playwright-cli close
+# Delete user data for the default session
+playwright-cli delete-data
+```
+
+## Snapshots
+
+After each command, playwright-cli provides a snapshot of the current browser state.
+
+```bash
+> playwright-cli goto https://example.com
+### Page
+- Page URL: https://example.com/
+- Page Title: Example Domain
+### Snapshot
+[Snapshot](.playwright-cli/page-2026-02-14T19-22-42-679Z.yml)
+```
+
+You can also take a snapshot on demand using `playwright-cli snapshot` command.
+
+If `--filename` is not provided, a new snapshot file is created with a timestamp. Default to automatic file naming, use `--filename=` when artifact is a part of the workflow result.
+
+## Browser Sessions
+
+```bash
+# create new browser session named "mysession" with persistent profile
+playwright-cli -s=mysession open example.com --persistent
+# same with manually specified profile directory (use when requested explicitly)
+playwright-cli -s=mysession open example.com --profile=/path/to/profile
+playwright-cli -s=mysession click e6
+playwright-cli -s=mysession close  # stop a named browser
+playwright-cli -s=mysession delete-data  # delete user data for persistent session
+
+playwright-cli list
+# Close all browsers
+playwright-cli close-all
+# Forcefully kill all browser processes
+playwright-cli kill-all
+```
+
+## Local installation
+
+In some cases user might want to install playwright-cli locally. If running globally available `playwright-cli` binary fails, use `npx playwright-cli` to run the commands. For example:
+
+```bash
+npx playwright-cli open https://example.com
+npx playwright-cli click e1
+```
+
+## Example: Form submission
+
+```bash
+playwright-cli open https://example.com/form
+playwright-cli snapshot
+
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Multi-tab workflow
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tab-new https://example.com/other
+playwright-cli tab-list
+playwright-cli tab-select 0
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Debugging with DevTools
+
+```bash
+playwright-cli open https://example.com
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli console
+playwright-cli network
+playwright-cli close
+```
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tracing-start
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli tracing-stop
+playwright-cli close
+```
+
+## Specific tasks
+
+- **Request mocking** [references/request-mocking.md](references/request-mocking.md)
+- **Running Playwright code** [references/running-code.md](references/running-code.md)
+- **Browser session management** [references/session-management.md](references/session-management.md)
+- **Storage state (cookies, localStorage)** [references/storage-state.md](references/storage-state.md)
+- **Test generation** [references/test-generation.md](references/test-generation.md)
+- **Tracing** [references/tracing.md](references/tracing.md)
+- **Video recording** [references/video-recording.md](references/video-recording.md)

--- a/tests/e2e/.claude/skills/playwright-cli/references/request-mocking.md
+++ b/tests/e2e/.claude/skills/playwright-cli/references/request-mocking.md
@@ -1,0 +1,87 @@
+# Request Mocking
+
+Intercept, mock, modify, and block network requests.
+
+## CLI Route Commands
+
+```bash
+# Mock with custom status
+playwright-cli route "**/*.jpg" --status=404
+
+# Mock with JSON body
+playwright-cli route "**/api/users" --body='[{"id":1,"name":"Alice"}]' --content-type=application/json
+
+# Mock with custom headers
+playwright-cli route "**/api/data" --body='{"ok":true}' --header="X-Custom: value"
+
+# Remove headers from requests
+playwright-cli route "**/*" --remove-header=cookie,authorization
+
+# List active routes
+playwright-cli route-list
+
+# Remove a route or all routes
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+## URL Patterns
+
+```
+**/api/users           - Exact path match
+**/api/*/details       - Wildcard in path
+**/*.{png,jpg,jpeg}    - Match file extensions
+**/search?q=*          - Match query parameters
+```
+
+## Advanced Mocking with run-code
+
+For conditional responses, request body inspection, response modification, or delays:
+
+### Conditional Response Based on Request
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/login', route => {
+    const body = route.request().postDataJSON();
+    if (body.username === 'admin') {
+      route.fulfill({ body: JSON.stringify({ token: 'mock-token' }) });
+    } else {
+      route.fulfill({ status: 401, body: JSON.stringify({ error: 'Invalid' }) });
+    }
+  });
+}"
+```
+
+### Modify Real Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/user', async route => {
+    const response = await route.fetch();
+    const json = await response.json();
+    json.isPremium = true;
+    await route.fulfill({ response, json });
+  });
+}"
+```
+
+### Simulate Network Failures
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/offline', route => route.abort('internetdisconnected'));
+}"
+# Options: connectionrefused, timedout, connectionreset, internetdisconnected
+```
+
+### Delayed Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/slow', async route => {
+    await new Promise(r => setTimeout(r, 3000));
+    route.fulfill({ body: JSON.stringify({ data: 'loaded' }) });
+  });
+}"
+```

--- a/tests/e2e/.claude/skills/playwright-cli/references/running-code.md
+++ b/tests/e2e/.claude/skills/playwright-cli/references/running-code.md
@@ -1,0 +1,232 @@
+# Running Custom Playwright Code
+
+Use `run-code` to execute arbitrary Playwright code for advanced scenarios not covered by CLI commands.
+
+## Syntax
+
+```bash
+playwright-cli run-code "async page => {
+  // Your Playwright code here
+  // Access page.context() for browser context operations
+}"
+```
+
+## Geolocation
+
+```bash
+# Grant geolocation permission and set location
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 37.7749, longitude: -122.4194 });
+}"
+
+# Set location to London
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 51.5074, longitude: -0.1278 });
+}"
+
+# Clear geolocation override
+playwright-cli run-code "async page => {
+  await page.context().clearPermissions();
+}"
+```
+
+## Permissions
+
+```bash
+# Grant multiple permissions
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions([
+    'geolocation',
+    'notifications',
+    'camera',
+    'microphone'
+  ]);
+}"
+
+# Grant permissions for specific origin
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read'], {
+    origin: 'https://example.com'
+  });
+}"
+```
+
+## Media Emulation
+
+```bash
+# Emulate dark color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+}"
+
+# Emulate light color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'light' });
+}"
+
+# Emulate reduced motion
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+}"
+
+# Emulate print media
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ media: 'print' });
+}"
+```
+
+## Wait Strategies
+
+```bash
+# Wait for network idle
+playwright-cli run-code "async page => {
+  await page.waitForLoadState('networkidle');
+}"
+
+# Wait for specific element
+playwright-cli run-code "async page => {
+  await page.waitForSelector('.loading', { state: 'hidden' });
+}"
+
+# Wait for function to return true
+playwright-cli run-code "async page => {
+  await page.waitForFunction(() => window.appReady === true);
+}"
+
+# Wait with timeout
+playwright-cli run-code "async page => {
+  await page.waitForSelector('.result', { timeout: 10000 });
+}"
+```
+
+## Frames and Iframes
+
+```bash
+# Work with iframe
+playwright-cli run-code "async page => {
+  const frame = page.locator('iframe#my-iframe').contentFrame();
+  await frame.locator('button').click();
+}"
+
+# Get all frames
+playwright-cli run-code "async page => {
+  const frames = page.frames();
+  return frames.map(f => f.url());
+}"
+```
+
+## File Downloads
+
+```bash
+# Handle file download
+playwright-cli run-code "async page => {
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.click('a.download-link')
+  ]);
+  await download.saveAs('./downloaded-file.pdf');
+  return download.suggestedFilename();
+}"
+```
+
+## Clipboard
+
+```bash
+# Read clipboard (requires permission)
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read']);
+  return await page.evaluate(() => navigator.clipboard.readText());
+}"
+
+# Write to clipboard
+playwright-cli run-code "async page => {
+  await page.evaluate(text => navigator.clipboard.writeText(text), 'Hello clipboard!');
+}"
+```
+
+## Page Information
+
+```bash
+# Get page title
+playwright-cli run-code "async page => {
+  return await page.title();
+}"
+
+# Get current URL
+playwright-cli run-code "async page => {
+  return page.url();
+}"
+
+# Get page content
+playwright-cli run-code "async page => {
+  return await page.content();
+}"
+
+# Get viewport size
+playwright-cli run-code "async page => {
+  return page.viewportSize();
+}"
+```
+
+## JavaScript Execution
+
+```bash
+# Execute JavaScript and return result
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => {
+    return {
+      userAgent: navigator.userAgent,
+      language: navigator.language,
+      cookiesEnabled: navigator.cookieEnabled
+    };
+  });
+}"
+
+# Pass arguments to evaluate
+playwright-cli run-code "async page => {
+  const multiplier = 5;
+  return await page.evaluate(m => document.querySelectorAll('li').length * m, multiplier);
+}"
+```
+
+## Error Handling
+
+```bash
+# Try-catch in run-code
+playwright-cli run-code "async page => {
+  try {
+    await page.click('.maybe-missing', { timeout: 1000 });
+    return 'clicked';
+  } catch (e) {
+    return 'element not found';
+  }
+}"
+```
+
+## Complex Workflows
+
+```bash
+# Login and save state
+playwright-cli run-code "async page => {
+  await page.goto('https://example.com/login');
+  await page.fill('input[name=email]', 'user@example.com');
+  await page.fill('input[name=password]', 'secret');
+  await page.click('button[type=submit]');
+  await page.waitForURL('**/dashboard');
+  await page.context().storageState({ path: 'auth.json' });
+  return 'Login successful';
+}"
+
+# Scrape data from multiple pages
+playwright-cli run-code "async page => {
+  const results = [];
+  for (let i = 1; i <= 3; i++) {
+    await page.goto(\`https://example.com/page/\${i}\`);
+    const items = await page.locator('.item').allTextContents();
+    results.push(...items);
+  }
+  return results;
+}"
+```

--- a/tests/e2e/.claude/skills/playwright-cli/references/session-management.md
+++ b/tests/e2e/.claude/skills/playwright-cli/references/session-management.md
@@ -1,0 +1,170 @@
+# Browser Session Management
+
+Run multiple isolated browser sessions concurrently with state persistence.
+
+## Named Browser Sessions
+
+Use `-s` flag to isolate browser contexts:
+
+```bash
+# Browser 1: Authentication flow
+playwright-cli -s=auth open https://app.example.com/login
+
+# Browser 2: Public browsing (separate cookies, storage)
+playwright-cli -s=public open https://example.com
+
+# Commands are isolated by browser session
+playwright-cli -s=auth fill e1 "user@example.com"
+playwright-cli -s=public snapshot
+```
+
+## Browser Session Isolation Properties
+
+Each browser session has independent:
+
+- Cookies
+- LocalStorage / SessionStorage
+- IndexedDB
+- Cache
+- Browsing history
+- Open tabs
+
+## Browser Session Commands
+
+```bash
+# List all browser sessions
+playwright-cli list
+
+# Stop a browser session (close the browser)
+playwright-cli close                # stop the default browser
+playwright-cli -s=mysession close   # stop a named browser
+
+# Stop all browser sessions
+playwright-cli close-all
+
+# Forcefully kill all daemon processes (for stale/zombie processes)
+playwright-cli kill-all
+
+# Delete browser session user data (profile directory)
+playwright-cli delete-data                # delete default browser data
+playwright-cli -s=mysession delete-data   # delete named browser data
+```
+
+## Environment Variable
+
+Set a default browser session name via environment variable:
+
+```bash
+export PLAYWRIGHT_CLI_SESSION="mysession"
+playwright-cli open example.com  # Uses "mysession" automatically
+```
+
+## Common Patterns
+
+### Concurrent Scraping
+
+```bash
+#!/bin/bash
+# Scrape multiple sites concurrently
+
+# Start all browsers
+playwright-cli -s=site1 open https://site1.com &
+playwright-cli -s=site2 open https://site2.com &
+playwright-cli -s=site3 open https://site3.com &
+wait
+
+# Take snapshots from each
+playwright-cli -s=site1 snapshot
+playwright-cli -s=site2 snapshot
+playwright-cli -s=site3 snapshot
+
+# Cleanup
+playwright-cli close-all
+```
+
+### A/B Testing Sessions
+
+```bash
+# Test different user experiences
+playwright-cli -s=variant-a open "https://app.com?variant=a"
+playwright-cli -s=variant-b open "https://app.com?variant=b"
+
+# Compare
+playwright-cli -s=variant-a screenshot
+playwright-cli -s=variant-b screenshot
+```
+
+### Persistent Profile
+
+By default, browser profile is kept in memory only. Use `--persistent` flag on `open` to persist the browser profile to disk:
+
+```bash
+# Use persistent profile (auto-generated location)
+playwright-cli open https://example.com --persistent
+
+# Use persistent profile with custom directory
+playwright-cli open https://example.com --profile=/path/to/profile
+```
+
+## Default Browser Session
+
+When `-s` is omitted, commands use the default browser session:
+
+```bash
+# These use the same default browser session
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli close  # Stops default browser
+```
+
+## Browser Session Configuration
+
+Configure a browser session with specific settings when opening:
+
+```bash
+# Open with config file
+playwright-cli open https://example.com --config=.playwright/my-cli.json
+
+# Open with specific browser
+playwright-cli open https://example.com --browser=firefox
+
+# Open in headed mode
+playwright-cli open https://example.com --headed
+
+# Open with persistent profile
+playwright-cli open https://example.com --persistent
+```
+
+## Best Practices
+
+### 1. Name Browser Sessions Semantically
+
+```bash
+# GOOD: Clear purpose
+playwright-cli -s=github-auth open https://github.com
+playwright-cli -s=docs-scrape open https://docs.example.com
+
+# AVOID: Generic names
+playwright-cli -s=s1 open https://github.com
+```
+
+### 2. Always Clean Up
+
+```bash
+# Stop browsers when done
+playwright-cli -s=auth close
+playwright-cli -s=scrape close
+
+# Or stop all at once
+playwright-cli close-all
+
+# If browsers become unresponsive or zombie processes remain
+playwright-cli kill-all
+```
+
+### 3. Delete Stale Browser Data
+
+```bash
+# Remove old browser data to free disk space
+playwright-cli -s=oldsession delete-data
+```

--- a/tests/e2e/.claude/skills/playwright-cli/references/storage-state.md
+++ b/tests/e2e/.claude/skills/playwright-cli/references/storage-state.md
@@ -1,0 +1,275 @@
+# Storage Management
+
+Manage cookies, localStorage, sessionStorage, and browser storage state.
+
+## Storage State
+
+Save and restore complete browser state including cookies and storage.
+
+### Save Storage State
+
+```bash
+# Save to auto-generated filename (storage-state-{timestamp}.json)
+playwright-cli state-save
+
+# Save to specific filename
+playwright-cli state-save my-auth-state.json
+```
+
+### Restore Storage State
+
+```bash
+# Load storage state from file
+playwright-cli state-load my-auth-state.json
+
+# Reload page to apply cookies
+playwright-cli open https://example.com
+```
+
+### Storage State File Format
+
+The saved file contains:
+
+```json
+{
+  "cookies": [
+    {
+      "name": "session_id",
+      "value": "abc123",
+      "domain": "example.com",
+      "path": "/",
+      "expires": 1735689600,
+      "httpOnly": true,
+      "secure": true,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": [
+    {
+      "origin": "https://example.com",
+      "localStorage": [
+        { "name": "theme", "value": "dark" },
+        { "name": "user_id", "value": "12345" }
+      ]
+    }
+  ]
+}
+```
+
+## Cookies
+
+### List All Cookies
+
+```bash
+playwright-cli cookie-list
+```
+
+### Filter Cookies by Domain
+
+```bash
+playwright-cli cookie-list --domain=example.com
+```
+
+### Filter Cookies by Path
+
+```bash
+playwright-cli cookie-list --path=/api
+```
+
+### Get Specific Cookie
+
+```bash
+playwright-cli cookie-get session_id
+```
+
+### Set a Cookie
+
+```bash
+# Basic cookie
+playwright-cli cookie-set session abc123
+
+# Cookie with options
+playwright-cli cookie-set session abc123 --domain=example.com --path=/ --httpOnly --secure --sameSite=Lax
+
+# Cookie with expiration (Unix timestamp)
+playwright-cli cookie-set remember_me token123 --expires=1735689600
+```
+
+### Delete a Cookie
+
+```bash
+playwright-cli cookie-delete session_id
+```
+
+### Clear All Cookies
+
+```bash
+playwright-cli cookie-clear
+```
+
+### Advanced: Multiple Cookies or Custom Options
+
+For complex scenarios like adding multiple cookies at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.context().addCookies([
+    { name: 'session_id', value: 'sess_abc123', domain: 'example.com', path: '/', httpOnly: true },
+    { name: 'preferences', value: JSON.stringify({ theme: 'dark' }), domain: 'example.com', path: '/' }
+  ]);
+}"
+```
+
+## Local Storage
+
+### List All localStorage Items
+
+```bash
+playwright-cli localstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli localstorage-get token
+```
+
+### Set Value
+
+```bash
+playwright-cli localstorage-set theme dark
+```
+
+### Set JSON Value
+
+```bash
+playwright-cli localstorage-set user_settings '{"theme":"dark","language":"en"}'
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli localstorage-delete token
+```
+
+### Clear All localStorage
+
+```bash
+playwright-cli localstorage-clear
+```
+
+### Advanced: Multiple Operations
+
+For complex scenarios like setting multiple values at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    localStorage.setItem('token', 'jwt_abc123');
+    localStorage.setItem('user_id', '12345');
+    localStorage.setItem('expires_at', Date.now() + 3600000);
+  });
+}"
+```
+
+## Session Storage
+
+### List All sessionStorage Items
+
+```bash
+playwright-cli sessionstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli sessionstorage-get form_data
+```
+
+### Set Value
+
+```bash
+playwright-cli sessionstorage-set step 3
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli sessionstorage-delete step
+```
+
+### Clear sessionStorage
+
+```bash
+playwright-cli sessionstorage-clear
+```
+
+## IndexedDB
+
+### List Databases
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(async () => {
+    const databases = await indexedDB.databases();
+    return databases;
+  });
+}"
+```
+
+### Delete Database
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    indexedDB.deleteDatabase('myDatabase');
+  });
+}"
+```
+
+## Common Patterns
+
+### Authentication State Reuse
+
+```bash
+# Step 1: Login and save state
+playwright-cli open https://app.example.com/login
+playwright-cli snapshot
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+
+# Save the authenticated state
+playwright-cli state-save auth.json
+
+# Step 2: Later, restore state and skip login
+playwright-cli state-load auth.json
+playwright-cli open https://app.example.com/dashboard
+# Already logged in!
+```
+
+### Save and Restore Roundtrip
+
+```bash
+# Set up authentication state
+playwright-cli open https://example.com
+playwright-cli eval "() => { document.cookie = 'session=abc123'; localStorage.setItem('user', 'john'); }"
+
+# Save state to file
+playwright-cli state-save my-session.json
+
+# ... later, in a new session ...
+
+# Restore state
+playwright-cli state-load my-session.json
+playwright-cli open https://example.com
+# Cookies and localStorage are restored!
+```
+
+## Security Notes
+
+- Never commit storage state files containing auth tokens
+- Add `*.auth-state.json` to `.gitignore`
+- Delete state files after automation completes
+- Use environment variables for sensitive data
+- By default, sessions run in-memory mode which is safer for sensitive operations

--- a/tests/e2e/.claude/skills/playwright-cli/references/test-generation.md
+++ b/tests/e2e/.claude/skills/playwright-cli/references/test-generation.md
@@ -1,0 +1,238 @@
+# Test Generation
+
+Generate Playwright test code automatically as you interact with the browser.
+
+## How It Works
+
+Every action you perform with `playwright-cli` generates corresponding Playwright TypeScript code.
+This code appears in the output and can be copied directly into your test files.
+
+## Example Workflow
+
+```bash
+# Start a session
+playwright-cli open https://example.com/login
+
+# Take a snapshot to see elements
+playwright-cli snapshot
+# Output shows: e1 [textbox "Email"], e2 [textbox "Password"], e3 [button "Sign In"]
+
+# Fill form fields - generates code automatically
+playwright-cli fill e1 "user@example.com"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+
+playwright-cli fill e2 "password123"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+
+playwright-cli click e3
+# Ran Playwright code:
+# await page.getByRole('button', { name: 'Sign In' }).click();
+```
+
+## Building a Test File
+
+The CLI generates raw Playwright code. Translate each line to `@anaconda/playwright-utils` functions and organize everything into the project's class-based Page Object Model. The five steps below follow a single sign-in flow end-to-end.
+
+### Step 1 — Capture actions with the CLI
+
+Interact with the page; the CLI records every action as raw Playwright code.
+
+```bash
+playwright-cli open https://example.com
+playwright-cli click e3   # clicks "Sign In" link
+# Ran Playwright code:
+# await page.getByRole('link', { name: 'Sign In' }).click();
+
+playwright-cli snapshot   # check the sign-in page that just loaded
+# [region, data-qa-id="sign-in-header"] Sign In
+```
+
+**Raw code generated:**
+
+```typescript
+await page.goto('https://example.com');
+await page.getByRole('link', { name: 'Sign In' }).click(); // role locator — fragile
+await expect(page.getByRole('heading')).toContainText('Sign In'); // text assertion — fragile
+```
+
+### Step 2 — Upgrade locators using the DOM snapshot
+
+The CLI defaults to role/text locators (tier 7). **This upgrade is mandatory, not optional** — if the snapshot reveals a `data-qa-id` or any `data-*` attribute, use it. Do not keep the CLI-generated role/text locator when a stable attribute exists.
+
+```
+Snapshot reveals:
+  [link, data-qa-id="sign-in-link"]   → getLocatorByTestId('sign-in-link')   tier 1  ← use this
+  [region, data-qa-id="sign-in-header"] → getLocatorByTestId('sign-in-header') tier 1  ← use this
+  [input, id="username"]              → '#username'                           tier 3  ← use this
+  [input, name="password"]            → '[name="password"]'                   tier 4  ← use this
+  (no stable attr on button)          → getLocatorByRole('button', ...)       tier 7  ← only now
+```
+
+Locator field conventions inside a class (full 9-tier priority in `references/locators.md`):
+
+- **Static** — `private readonly field = 'css-or-xpath'` — plain string for tiers 3–6 (`#id`, `[name="x"]`, XPath/CSS with stable attrs). Passed directly to utility calls.
+- **Dynamic** — `private readonly field = () => getLocatorFn(...)` — arrow function for tiers 1–2 (`getLocatorByTestId`), tier 7 built-ins, or `.or()` compound locators. Arrow functions are lazy — they resolve after `setPage()` is called.
+- **Never** `.first()` / `.last()` / `.nth(N)` — see below.
+
+#### When the same locator matches multiple elements
+
+Action functions already enforce `onlyVisible: true` — hidden duplicates are filtered automatically. If multiple **visible** elements still match, find a more specific locator:
+
+1. Look for a `data-qa-id` / `id` / `data-*` on the target or a stable ancestor, then scope:
+   ```typescript
+   // Instead of: getLocatorByText('Pending').nth(2)
+   '[data-qa-id="channel-list"] [data-qa-id="pending-btn"]'; // CSS ancestor scope
+   '//tr[@data-qa-id="latest-row"]//button[@aria-label="Pending"]'; // XPath ancestor scope
+   ```
+2. If no ancestor attribute exists, write a custom XPath using structural context + stable attributes
+3. `.nth()` / `.first()` / `.last()` are last resort only — add a comment if you must use one
+
+### Step 3 — Create page object classes
+
+Page objects live in `tests/pages/`. Use destructured imports from `@anaconda/playwright-utils` — never namespace objects (`ActionUtils.xxx`) or raw Playwright API calls.
+
+```typescript
+// tests/pages/home-page.ts
+import { clickAndNavigate, getLocatorByTestId, gotoURL } from '@anaconda/playwright-utils';
+
+export class HomePage {
+  // CLI: page.getByRole('link', { name: 'Sign In' }) — snapshot showed data-qa-id instead
+  private readonly signInButton = () => getLocatorByTestId('sign-in-link'); // tier 1
+
+  async goToHomePage(): Promise<void> {
+    await gotoURL('https://example.com');
+  }
+
+  async clickSignIn(): Promise<void> {
+    // clickAndNavigate (not click) — this link loads a new page
+    await clickAndNavigate(this.signInButton());
+  }
+}
+```
+
+```typescript
+// tests/pages/sign-in-page.ts
+import { expectElementToBeVisible, getLocatorByTestId } from '@anaconda/playwright-utils';
+
+export class SignInPage {
+  // CLI: page.getByRole('heading') — snapshot showed data-qa-id instead
+  private readonly pageHeader = () => getLocatorByTestId('sign-in-header'); // tier 1
+
+  async verifySignInPageLoaded(): Promise<void> {
+    // expectElementToBeVisible (not text assertion) — verifies the page loaded, not copy
+    await expectElementToBeVisible(this.pageHeader(), 'Sign-in page header should be visible after navigation');
+  }
+}
+```
+
+### Step 4 — Register classes in the fixture file
+
+Extend the base `test` fixture so every spec receives page object instances automatically. The base fixture also calls `setPage(page)` before each test, which is required by all `@anaconda/playwright-utils` functions.
+
+```typescript
+// tests/fixtures/fixture.ts
+import { test as baseTest } from '@anaconda/playwright-utils';
+import { HomePage } from '@pages/home-page';
+import { SignInPage } from '@pages/sign-in-page';
+
+export const test = baseTest.extend<{
+  homePage: HomePage;
+  signInPage: SignInPage;
+}>({
+  homePage: async ({}, use) => {
+    await use(new HomePage());
+  },
+  signInPage: async ({}, use) => {
+    await use(new SignInPage());
+  },
+});
+
+export const expect = test.expect;
+```
+
+### Step 5 — Write the spec file
+
+Import `test` from `@fixture` (not `@playwright/test`). Destructure page object fixtures. Spec files only call page object methods — no actions or assertions directly in specs.
+
+```typescript
+// tests/specs/sign-in.spec.ts
+import { test } from '@fixture';
+
+test.describe('Sign-in flow @smoke', () => {
+  test('goes to sign-in page correctly', async ({ homePage, signInPage }) => {
+    await homePage.goToHomePage();
+    await homePage.clickSignIn();
+    await signInPage.verifySignInPageLoaded();
+  });
+});
+```
+
+See the full CLI-to-library mapping table in `.claude/skills/anaconda-playwright-utils/SKILL.md`.
+
+## Best Practices
+
+### 1. Prefer Stable Locators Over Role/Text
+
+The CLI often generates role- or text-based locators. **Replace them with stable selectors** (tiers 1–6) before adding to a page object. Role/text locators (tier 7) are a last resort — they break when copy or locale changes.
+
+```typescript
+// CLI generates (tier 7 — fragile, text can change)
+await page.getByRole('button', { name: 'Submit' }).click();
+await page.getByText('Order complete').click();
+
+// Translate to stable selectors first (tiers 1–3 preferred)
+private readonly submitButton = () => getLocatorByTestId('submit-order');  // tier 1 — data-qa-id
+private readonly successMessage = '[data-test="complete-header"]';         // tier 2 — data-*
+private readonly usernameInput = '#user-name';                             // tier 3 — id
+```
+
+See the full 9-tier priority in `references/locators.md`.
+
+### 2. Explore Before Recording
+
+Take snapshots to understand the page structure before recording actions:
+
+```bash
+playwright-cli open https://example.com
+playwright-cli snapshot
+# Review the element structure
+playwright-cli click e5
+```
+
+### 3. Choose the correct Click Action
+
+The CLI always generates `page.locator(...).click()`. When translating, pick the correct library function based on whether the click triggers a page navigation:
+
+| Scenario                                                         | Use                  |
+| ---------------------------------------------------------------- | -------------------- |
+| Click opens a dropdown, modal, or accordion (same page)          | `click()`            |
+| Click adds to cart, submits AJAX form, toggles state (same page) | `click()`            |
+| Click navigates to a new page (link, form redirect)              | `clickAndNavigate()` |
+
+```typescript
+// CLI generates (always .click() — doesn't know if navigation follows)
+await page.locator('#add-to-cart').click();
+await page.locator('#login-button').click();
+
+// Translate: ask "does this load a new page?"
+await click(this.addToCartButton()); // no — stays on product page
+await clickAndNavigate(this.loginButton()); // yes — redirects to dashboard
+```
+
+Using `click()` when navigation follows will cause the next action to run before the new page has loaded. `clickAndNavigate()` waits for three things in order: the `framenavigated` event, the page load state, and the clicked element becoming stale/hidden — confirming the old page is fully gone before the test continues.
+
+See full signatures in `references/actions.md`.
+
+### 4. Add Assertions Manually
+
+Generated code captures actions but not assertions. Add expectations in `verify*` methods inside the page object using stable selectors and a descriptive error message:
+
+```typescript
+// Generated action (translated to library)
+await clickAndNavigate(this.submitButton());
+
+// Add assertion in page object — stable selector + error message
+await expectElementToBeVisible(this.successMessage, 'Success message should be visible after form submission');
+```

--- a/tests/e2e/.claude/skills/playwright-cli/references/tracing.md
+++ b/tests/e2e/.claude/skills/playwright-cli/references/tracing.md
@@ -1,0 +1,156 @@
+# Tracing
+
+Capture detailed execution traces for debugging and analysis. Traces include DOM snapshots, screenshots, network activity, and console logs.
+
+## Viewing Traces
+
+After stopping a trace, open it with Playwright's built-in trace viewer:
+
+```bash
+# Open trace viewer in browser
+npx playwright show-trace traces/trace-<timestamp>.trace
+
+# Or upload to the online viewer
+# https://trace.playwright.dev
+```
+
+The trace viewer shows a timeline of every action, DOM snapshot before/after each step, network requests, console messages, and screenshots — all in a single UI.
+
+## Basic Usage
+
+```bash
+# Start trace recording
+playwright-cli tracing-start
+
+# Perform actions
+playwright-cli open https://example.com
+playwright-cli click e1
+playwright-cli fill e2 "test"
+
+# Stop trace recording
+playwright-cli tracing-stop
+```
+
+## Trace Output Files
+
+When you start tracing, Playwright creates a `traces/` directory with several files:
+
+### `trace-{timestamp}.trace`
+
+**Action log** - The main trace file containing:
+
+- Every action performed (clicks, fills, navigations)
+- DOM snapshots before and after each action
+- Screenshots at each step
+- Timing information
+- Console messages
+- Source locations
+
+### `trace-{timestamp}.network`
+
+**Network log** - Complete network activity:
+
+- All HTTP requests and responses
+- Request headers and bodies
+- Response headers and bodies
+- Timing (DNS, connect, TLS, TTFB, download)
+- Resource sizes
+- Failed requests and errors
+
+### `resources/`
+
+**Resources directory** - Cached resources:
+
+- Images, fonts, stylesheets, scripts
+- Response bodies for replay
+- Assets needed to reconstruct page state
+
+## What Traces Capture
+
+| Category        | Details                                            |
+| --------------- | -------------------------------------------------- |
+| **Actions**     | Clicks, fills, hovers, keyboard input, navigations |
+| **DOM**         | Full DOM snapshot before/after each action         |
+| **Screenshots** | Visual state at each step                          |
+| **Network**     | All requests, responses, headers, bodies, timing   |
+| **Console**     | All console.log, warn, error messages              |
+| **Timing**      | Precise timing for each operation                  |
+
+## Use Cases
+
+### Debugging Failed Actions
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://app.example.com
+
+# This click fails - why?
+playwright-cli click e5
+
+playwright-cli tracing-stop
+# Open trace to see DOM state when click was attempted
+```
+
+### Analyzing Performance
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://slow-site.com
+playwright-cli tracing-stop
+
+# View network waterfall to identify slow resources
+```
+
+### Capturing Evidence
+
+```bash
+# Record a complete user flow for documentation
+playwright-cli tracing-start
+
+playwright-cli open https://app.example.com/checkout
+playwright-cli fill e1 "4111111111111111"
+playwright-cli fill e2 "12/25"
+playwright-cli fill e3 "123"
+playwright-cli click e4
+
+playwright-cli tracing-stop
+# Trace shows exact sequence of events
+```
+
+## Trace vs Video vs Screenshot
+
+| Feature                 | Trace       | Video       | Screenshot       |
+| ----------------------- | ----------- | ----------- | ---------------- |
+| **Format**              | .trace file | .webm video | .png/.jpeg image |
+| **DOM inspection**      | Yes         | No          | No               |
+| **Network details**     | Yes         | No          | No               |
+| **Step-by-step replay** | Yes         | Continuous  | Single frame     |
+| **File size**           | Medium      | Large       | Small            |
+| **Best for**            | Debugging   | Demos       | Quick capture    |
+
+## Best Practices
+
+### 1. Start Tracing Before the Problem
+
+```bash
+# Trace the entire flow, not just the failing step
+playwright-cli tracing-start
+playwright-cli open https://example.com
+# ... all steps leading to the issue ...
+playwright-cli tracing-stop
+```
+
+### 2. Clean Up Old Traces
+
+Traces can consume significant disk space:
+
+```bash
+# Remove traces older than 7 days
+find .playwright-cli/traces -mtime +7 -delete
+```
+
+## Limitations
+
+- Traces add overhead to automation
+- Large traces can consume significant disk space
+- Some dynamic content may not replay perfectly

--- a/tests/e2e/.claude/skills/playwright-cli/references/video-recording.md
+++ b/tests/e2e/.claude/skills/playwright-cli/references/video-recording.md
@@ -1,0 +1,87 @@
+# Video Recording
+
+Capture browser automation sessions as video for debugging, documentation, or verification. Produces WebM (VP8/VP9 codec).
+
+## Basic Recording
+
+```bash
+# Start recording
+playwright-cli video-start
+
+# Perform actions
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli click e1
+playwright-cli fill e2 "test input"
+
+# Stop and save
+playwright-cli video-stop demo.webm
+```
+
+## Viewing Recordings
+
+WebM files can be opened in any modern browser or video player (VLC, QuickTime, Chrome, Firefox):
+
+```bash
+# Open in browser directly
+open recordings/login-flow.webm
+
+# Or serve locally
+npx serve recordings/
+```
+
+## Common Patterns
+
+### Record a failing test flow for bug reports
+
+```bash
+playwright-cli open https://app.example.com
+playwright-cli video-start
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "wrongpassword"
+playwright-cli click e3
+playwright-cli video-stop recordings/login-failure.webm
+playwright-cli close
+```
+
+### Record a complete feature demo
+
+```bash
+playwright-cli open https://app.example.com
+playwright-cli video-start
+# ... walk through the full feature ...
+playwright-cli video-stop recordings/feature-demo-$(date +%Y%m%d).webm
+playwright-cli close
+```
+
+## Best Practices
+
+### 1. Use Descriptive Filenames
+
+```bash
+# Include context in filename
+playwright-cli video-stop recordings/login-flow-2024-01-15.webm
+playwright-cli video-stop recordings/checkout-test-run-42.webm
+```
+
+### 2. Clean Up Large Recordings
+
+```bash
+# Remove recordings older than 30 days
+find recordings/ -name "*.webm" -mtime +30 -delete
+```
+
+## Tracing vs Video
+
+| Feature  | Video                | Tracing                                  |
+| -------- | -------------------- | ---------------------------------------- |
+| Output   | WebM file            | Trace file (viewable in Trace Viewer)    |
+| Shows    | Visual recording     | DOM snapshots, network, console, actions |
+| Use case | Demos, documentation | Debugging, analysis                      |
+| Size     | Larger               | Smaller                                  |
+
+## Limitations
+
+- Recording adds slight overhead to automation
+- Large recordings can consume significant disk space
+- WebM (VP8/VP9) — ensure your video player supports this codec

--- a/tests/e2e/.cursor/rules/anaconda-playwright-utils.mdc
+++ b/tests/e2e/.cursor/rules/anaconda-playwright-utils.mdc
@@ -1,0 +1,112 @@
+---
+description: Use @anaconda/playwright-utils for Playwright tests. Follow locator strategy (data-qa-id, data-testid, role, label). Use with playwright-cli to verify flows.
+globs: ["**/*.spec.ts", "**/*.test.ts", "tests/**"]
+---
+
+# @anaconda/playwright-utils
+
+Playwright TypeScript utility library with simplified helper functions for browser automation.
+
+## Quick Reference
+
+- **Must call `setPage(page)` before using any utility** — the `@fixture` import handles this automatically
+- Functions accept `string | Locator` as input
+- Import from main package: `import { click, fill, expectElementToBeVisible, logger } from '@anaconda/playwright-utils';`
+- **`logger`** — Winston-based logger, available from the same import. Use only in page objects for informational messages. Never use `console.log()` anywhere in tests.
+
+## Locator Priority (9 tiers, best → worst)
+
+| Tier | Type | Example |
+|------|------|---------|
+| 1 | `data-qa-id` | `getLocatorByTestId('submit-btn')` — **never** raw CSS `[data-qa-id="..."]` for a single element |
+| 2 | `data-testid` (configured testIdAttribute) | `getLocatorByTestId('submit')` — CSS only for other `data-*` like `[data-product-id="..."]` |
+| 3 | `id` | `'#username'` |
+| 4 | `name` | `'[name="email"]'` |
+| 5 | XPath with stable attrs | `'//button[@aria-label="Close"]'` |
+| 6 | CSS with stable attrs | `'button[aria-label="Close"]'` |
+| 7 | Playwright built-ins | `getLocatorByRole(...)`, `getLocatorByText(...)` — only when no stable attr exists |
+| 8–9 | Structural XPath/CSS | Last resort — fragile |
+
+Full strategy and field conventions: @file .claude/skills/anaconda-playwright-utils/references/locators.md
+
+## Anti-patterns — never do these
+
+**❌ Keep a role/text locator when the snapshot shows a stable attribute**
+```typescript
+// Snapshot shows data-qa-id="sign-in-link" → upgrade, do not keep CLI output
+private readonly signIn = () => getLocatorByRole('link', { name: 'Sign In' }); // ❌
+private readonly signIn = () => getLocatorByTestId('sign-in-link');             // ✅
+```
+
+**❌ Use raw CSS for a single `data-qa-id` or `data-testid` element**
+```typescript
+private readonly releaseType = '[data-qa-id="release-type"]';   // ❌
+private readonly submitBtn   = '[data-testid="submit-btn"]';    // ❌
+// ✅ Always use getLocatorByTestId for the configured testIdAttribute
+private readonly releaseType = () => getLocatorByTestId('release-type'); // ✅
+private readonly submitBtn   = () => getLocatorByTestId('submit-btn');   // ✅
+```
+
+**❌ Use `.nth()` / `.first()` / `.last()` when multiple elements match**
+
+Action functions already filter hidden elements — if multiple visible elements match, find a more specific locator using ancestor scoping:
+```typescript
+private readonly pendingBtn = () => getLocatorByText('Pending').first(); // ❌
+
+// Simple 1-level scoping — prefer getLocatorByTestId chaining
+private readonly channelItem = () =>
+  getLocatorByTestId('channel-list').locator('[data-qa-id="channel-item"]'); // ✅
+// Complex scoping (2+ ancestor levels or mixed types) — CSS compound is preferred
+private readonly pendingBtn = '[data-qa-id="channel-list"] [data-qa-id="pending-btn"]'; // ✅ compound scope
+```
+
+**❌ Omit error messages from assertions**
+```typescript
+await expectElementToBeVisible(this.header());                                          // ❌
+await expectElementToBeVisible(this.header(), 'Header should be visible after login');  // ✅
+```
+Every assertion function accepts a descriptive message as its last argument. Always include it.
+
+**❌ Add `waitForPageLoadState` after `clickAndNavigate`**
+```typescript
+await clickAndNavigate(this.loginButton());
+await waitForPageLoadState({ waitUntil: 'load' }); // ❌ redundant — already done internally
+```
+`clickAndNavigate` already waits for `framenavigated`, load state, and element staleness.
+
+**❌ Use `console.log()` in any test file**
+```typescript
+console.log('user logged in');  // ❌ never in page objects or specs
+logger.info('user logged in');  // ✅ use logger from @anaconda/playwright-utils in page objects only
+```
+
+**❌ Put assertions directly in spec files**
+```typescript
+// ❌ — assertions belong in page object verify* methods
+test('should show dashboard', async ({ page }) => {
+  await expectElementToBeVisible('.dashboard');
+});
+// ✅ — spec only calls page object methods
+test('should show dashboard', async ({ dashboardPage }) => {
+  await dashboardPage.verifyDashboardIsDisplayed();
+});
+```
+
+**❌ Put test data inline in spec files**
+```typescript
+// ❌ inline test data
+await userAPI.createUser({ name: 'John', email: 'john@example.com' });
+// ✅ import from testdata folder
+import { testUsers } from '@testdata/users';
+await userAPI.createUser(testUsers.validUser);
+```
+
+## Full API Documentation
+
+@file .claude/skills/anaconda-playwright-utils/SKILL.md
+@file .claude/skills/anaconda-playwright-utils/references/actions.md
+@file .claude/skills/anaconda-playwright-utils/references/assertions.md
+@file .claude/skills/anaconda-playwright-utils/references/locators.md
+@file .claude/skills/anaconda-playwright-utils/references/element-utils.md
+@file .claude/skills/anaconda-playwright-utils/references/api-utils.md
+@file .claude/skills/anaconda-playwright-utils/references/page-utils.md

--- a/tests/e2e/.cursor/rules/playwright-agents.mdc
+++ b/tests/e2e/.cursor/rules/playwright-agents.mdc
@@ -1,0 +1,30 @@
+---
+description: Playwright test agent workflows for planning, generating, and healing tests
+globs: ["**/*.spec.ts", "**/*.test.ts", "specs/**", "tests/**"]
+---
+
+# Playwright Test Agent Workflows
+
+When working on Playwright tests you **must**:
+
+1. **Use `playwright-cli`** to verify flows — run `playwright-cli open <url>`, `playwright-cli snapshot`, then interact (click, fill) to capture real selectors. Never guess selectors.
+2. **Follow the locator strategy** in `.claude/skills/anaconda-playwright-utils/references/locators.md` when writing selectors. Key rule: whenever an element has `data-qa-id`, **always use `getLocatorByTestId('value')`** — never write `[data-qa-id="value"]` as a raw CSS selector.
+3. **Use the right agent workflow** when the user asks to:
+   - Create a test plan or explore an app → **Test Planner**
+   - Generate a test from a plan or scenario → **Test Generator**
+   - Fix a failing test → **Test Healer**
+4. **Format code** — run `npx prettier --write` on any `.ts` files you create or edit.
+5. **Find test files by context** — When the user doesn't specify a file path, search `tests/specs/` and `tests/pages/` for files matching the user's intent (by app name, feature keyword, or URL domain) before creating new files. Follow existing naming conventions.
+6. **Optimize token usage** — Start with `WebFetch` for page reconnaissance before opening `playwright-cli`, especially in the planner and healer. Only escalate to browser when interactive discovery or selector capture is needed. Users can say "use browser mode" to skip this or "use lite mode" to maximize it.
+
+## Agents
+
+1. **Test Planner** - Explores a web app and creates a comprehensive test plan in `specs/`
+2. **Test Generator** - Executes test plan steps in the browser and generates test files using `@anaconda/playwright-utils`
+3. **Test Healer** - Debugs and fixes failing Playwright tests
+
+## Agent Details
+
+@file .claude/agents/playwright-test-planner.md
+@file .claude/agents/playwright-test-generator.md
+@file .claude/agents/playwright-test-healer.md

--- a/tests/e2e/.cursor/rules/project.mdc
+++ b/tests/e2e/.cursor/rules/project.mdc
@@ -1,0 +1,33 @@
+---
+description: Project-wide instructions and conventions
+globs: ["**/*"]
+alwaysApply: true
+---
+
+# Project Conventions (Quick Reference)
+
+## Imports
+- Always import `test` from `@fixture`, never from `@playwright/test` or `@anaconda/playwright-utils` directly in specs
+- Use a single barrel import from `@anaconda/playwright-utils` for all utilities (click, fill, gotoURL, expect, logger, etc.)
+- Use TypeScript path aliases: `@pages/*`, `@testdata/*`, `@fixture`, `@playwright-config`
+
+## Page Object Model
+- All page logic lives in class-based page objects in `tests/pages/` — specs only call page object methods
+- All assertions live in `verify*` methods in page objects — never in spec files
+- All actions (click, fill, gotoURL) go in page object methods — never in spec files
+- Register every new page object in `tests/fixtures/fixture.ts` via `baseTest.extend<>()`
+
+## Locator Priority (9 tiers, best → worst)
+`data-qa-id` → `data-testid`/`data-*` → `id` → `name` → XPath (stable attrs) → CSS (stable attrs) → role/text (tier 7, last resort) → structural XPath/CSS
+
+## Key Rules
+- Use `clickAndNavigate()` for clicks that load a new page; `click()` for same-page interactions only
+- Never add `waitForPageLoadState` after `clickAndNavigate` — it's redundant
+- Never use `.nth()` / `.first()` / `.last()` — use ancestor-scoped selectors instead
+- Every assertion must include a descriptive error message as the last argument
+- Never use `console.log()` — use `logger` from `@anaconda/playwright-utils` in page objects only
+- Store test data in `tests/testdata/` and import it — never hardcode inline in specs
+- Wrap all tests in a `test.describe` block with a tag (`@smoke`, `@reg`)
+
+## Full Reference
+@file CLAUDE.md

--- a/tests/e2e/CLAUDE.md
+++ b/tests/e2e/CLAUDE.md
@@ -1,0 +1,379 @@
+# Playwright TypeScript Project
+
+## Project Overview
+
+A Playwright TypeScript end-to-end testing framework for Web (Desktop & Mobile), API, and Electron apps. Built on top of `@anaconda/playwright-utils` which provides simplified utility functions for actions, assertions, locators, elements, page management, and API requests.
+
+**Repository**: `anaconda/playwright-ts-utils`
+**Default test target**: https://www.saucedemo.com (configurable via `URL` env var or `.env` file)
+**AI Tools**: Claude Code and Cursor (skills and agents shared via `.claude/` and `.cursor/rules/`). In **Cursor IDE**, whenever you use **`@.claude/skills/`**, include **`@.cursor/`** in the same context—see [AI Skills and Agents](#ai-skills-and-agents).
+
+## Project Structure
+
+```
+playwright-ts-template/
+├── playwright.config.ts          # Playwright configuration (projects, timeouts, reporters)
+├── test-setup/
+│   ├── page-setup.ts             # Sets page context via setPage() before each test
+│   ├── global-setup.ts           # Runs before all tests (initialization hooks)
+│   └── global-teardown.ts        # Runs after all tests (cleanup hooks)
+├── tests/
+│   ├── specs/                    # Test spec files (*.spec.ts)
+│   ├── pages/                    # Page Object classes (class-based POM)
+│   ├── fixtures/
+│   │   └── fixture.ts            # Custom Playwright fixtures for page objects
+│   ├── testdata/                 # Test data files
+│   └── storage-setup/            # Authentication storage state setup
+├── .claude/
+│   ├── skills/
+│   │   ├── anaconda-playwright-utils/ # API docs, locator strategy, browser strategy, function references
+│   │   └── playwright-cli/            # Browser automation CLI commands and references
+│   └── agents/                        # Agent workflows (planner, generator, healer)
+└── .cursor/rules/                 # Cursor rules referencing .claude/ skills and agents via @file
+```
+
+## Key Conventions
+
+### Imports and Path Aliases
+
+Use TypeScript path aliases defined in `tsconfig.json`:
+
+- `@pages/*` -> `tests/pages/*`
+- `@testdata/*` -> `tests/testdata/*`
+- `@fixture` -> `tests/fixtures/fixture`
+- `@playwright-config` -> `playwright.config`
+
+### Page Setup
+
+Always import `test` from `@fixture` instead of `@playwright/test`. This ensures `setPage(page)` is called before each test (required by all `@anaconda/playwright-utils` functions) and provides page object class instances as fixtures.
+
+```typescript
+import { test } from '@fixture';
+```
+
+The fixture setup (`tests/fixtures/fixture.ts`) extends the base test from `@anaconda/playwright-utils` (which sets `setPage(page)` per test) and registers page object classes as Playwright fixtures.
+
+### Use @anaconda/playwright-utils Functions
+
+Always prefer `@anaconda/playwright-utils` utility functions over raw Playwright API calls.
+
+**Imports:** The package re-exports actions, assertions, locators, element helpers, page helpers, and **constants** (e.g. `STANDARD_TIMEOUT`, `NAVIGATION_TIMEOUT`) from its main entry. **Use one combined import from `@anaconda/playwright-utils`** for everything you need from that library—do not split the same symbols across multiple import lines or duplicate imports from the root package. Subpath imports (e.g. `@anaconda/playwright-utils/action-utils`) are optional (e.g. for tree-shaking); if you use them, avoid mixing redundant root + subpath imports for the same helpers. ESLint in this repo enforces **sorted named imports** (e.g. `sort-imports` may place uppercase exports like `STANDARD_TIMEOUT` before lowercase names—run `npm run lint:fix` if needed).
+
+```typescript
+// DO: Single barrel import; utility functions + constants as needed
+import {
+  STANDARD_TIMEOUT,
+  click,
+  clickAndNavigate,
+  expectElementToBeVisible,
+  fill,
+  getLocatorByRole,
+  getLocatorByTestId,
+  getLocatorByText,
+  gotoURL,
+  logger, // Winston-based logger — use sparingly in page objects only, never in spec files
+} from '@anaconda/playwright-utils';
+import { urlData } from '@testdata/urls-testdata';
+import { userData } from '@testdata/user-testdata';
+
+await gotoURL(urlData.loginPageUrl);
+await fill('#username', userData.username);
+await clickAndNavigate(getLocatorByRole('button', { name: 'Login' }));
+await expectElementToBeVisible('.dashboard', 'Dashboard should be visible after login');
+
+// DON'T: Use raw Playwright API
+await page.goto('https://example.com');
+await page.locator('#username').fill('user');
+await page.getByRole('button', { name: 'Login' }).click();
+```
+
+### Page Object Model (Class-based)
+
+All page objects use class-based POM in `tests/pages/`. Classes use `@anaconda/playwright-utils` functions internally and are registered as Playwright fixtures in `tests/fixtures/fixture.ts`.
+
+**Page object class** (`tests/pages/login-page.ts`):
+
+```typescript
+import {
+  clickAndNavigate,
+  expectElementToBeAttached,
+  expectElementToBeVisible,
+  fill,
+  getLocator,
+  getLocatorByPlaceholder,
+  getLocatorByRole,
+  gotoURL,
+} from '@anaconda/playwright-utils';
+import { urlData } from '@testdata/urls-testdata';
+import { userData } from '@testdata/user-testdata';
+
+export class LoginPage {
+  // Static selectors — plain strings for simple CSS/XPath
+  private readonly usernameInput = '#user-name';
+  // Dynamic locators — arrow functions for chained or compound locators
+  private readonly passwordInput = () => getLocator('#password').or(getLocatorByPlaceholder('Password'));
+  private readonly loginButton = () => getLocatorByRole('button', { name: 'Login' });
+
+  async navigateToLoginPage(): Promise<void> {
+    await gotoURL(urlData.loginPageUrl);
+  }
+
+  async loginWithValidCredentials(): Promise<void> {
+    await fill(this.usernameInput, userData.username);
+    await fill(this.passwordInput(), userData.pwd);
+    await clickAndNavigate(this.loginButton());
+    await expectElementToBeAttached(this.usernameInput, 'User should be logged in');
+  }
+
+  async verifyLoginPageIsDisplayed(): Promise<void> {
+    await expectElementToBeVisible(this.usernameInput, 'Login page should be displayed');
+  }
+}
+```
+
+**Fixture registration** (`tests/fixtures/fixture.ts`):
+
+```typescript
+import { test as baseTest } from '@anaconda/playwright-utils';
+import { LoginPage } from '@pages/login-page';
+import { ProductsPage } from '@pages/products-page';
+
+export const test = baseTest.extend<{
+  loginPage: LoginPage;
+  productsPage: ProductsPage;
+}>({
+  loginPage: async ({}, use) => {
+    await use(new LoginPage());
+  },
+  productsPage: async ({}, use) => {
+    await use(new ProductsPage());
+  },
+});
+```
+
+**Spec file** (`tests/specs/products.spec.ts`):
+
+```typescript
+import { test } from '@fixture';
+
+test.describe('Products page @smoke', () => {
+  test.beforeEach(async ({ loginPage }) => {
+    await loginPage.navigateToLoginPage();
+    await loginPage.loginWithValidCredentials();
+  });
+
+  test('should display products page', async ({ productsPage }) => {
+    await productsPage.verifyProductsPageIsDisplayed();
+  });
+
+  test('should show product count', async ({ productsPage }) => {
+    await productsPage.verifyProductCount(6);
+  });
+});
+```
+
+When creating new page objects, add them as fixtures in `tests/fixtures/fixture.ts`.
+
+### Locator Strategy
+
+Follow the 9-tier priority order in `.claude/skills/anaconda-playwright-utils/references/locators.md` (best to worst):
+
+1. `data-qa-id` attributes (best) -> `getLocatorByTestId()` — **never** raw CSS `[data-qa-id="..."]` for a single element
+2. `data-testid` (configured testIdAttribute) -> `getLocatorByTestId()` — CSS only for other `data-*` like `[data-product-id="..."]`
+3. `id` attributes -> `#id` or `[id="..."]`
+4. `name` attributes -> `[name="..."]`
+5. XPath with unique attributes -> `//button[@aria-label="Submit"]`
+6. CSS with unique attributes -> `button[aria-label="Submit"]`, `input[type="email"]`
+7. Playwright built-in locators (only when no stable selector exists) -> `getLocatorByRole()`, `getLocatorByLabel()`, `getLocatorByPlaceholder()`, `getLocatorByText()`
+8. XPath structural (fragile) -> `//div[@class="form"][2]//button`
+9. CSS structural (fragile, last resort) -> `.form-group:nth-child(2) button`
+
+**Mandatory upgrade rule:** If a DOM snapshot reveals a `data-qa-id` or any `data-*` attribute, always use it — never keep a role/text locator when a stable attribute exists.
+
+**Multiple-element matches:** Action functions already filter hidden elements internally. If multiple visible elements still match, find a more specific locator using ancestor scoping — never use `.nth()`, `.first()`, or `.last()`:
+
+```typescript
+// ❌ Avoid — index breaks silently when the page changes
+getLocatorByText('Pending').nth(2);
+
+// ✅ Simple 1-level scoping — prefer getLocatorByTestId chaining
+getLocatorByTestId('channel-list').locator('[data-qa-id="channel-item"]');
+// ✅ Complex scoping (2+ levels or mixed types) — CSS compound is preferred
+('[data-qa-id="channel-list"] [data-qa-id="pending-btn"]');
+// ✅ XPath ancestor scope
+('//tr[@data-qa-id="latest-row"]//button[@aria-label="Pending"]');
+```
+
+### Common Anti-patterns
+
+```typescript
+// ❌ Role/text locator when snapshot shows data-qa-id — always upgrade
+private readonly signIn = () => getLocatorByRole('link', { name: 'Sign In' }); // ❌
+private readonly signIn = () => getLocatorByTestId('sign-in-link');             // ✅
+
+// ❌ Raw CSS for a single data-qa-id or data-testid element — always use getLocatorByTestId
+private readonly releaseType = '[data-qa-id="release-type"]';   // ❌
+private readonly submitBtn   = '[data-testid="submit-btn"]';    // ❌
+private readonly releaseType = () => getLocatorByTestId('release-type'); // ✅
+private readonly submitBtn   = () => getLocatorByTestId('submit-btn');   // ✅
+
+// ❌ Omit error messages from assertions — always include a descriptive message
+await expectElementToBeVisible(this.header());                                          // ❌
+await expectElementToBeVisible(this.header(), 'Header should be visible after login');  // ✅
+
+// ❌ waitForPageLoadState after clickAndNavigate — redundant, already done internally
+await clickAndNavigate(this.loginButton());
+await waitForPageLoadState({ waitUntil: 'load' }); // ❌ remove this line
+```
+
+### Action and Assertion Reference
+
+- **Actions**: `.claude/skills/anaconda-playwright-utils/references/actions.md` - click, fill, select, check, hover, drag, upload, alerts
+- **Assertions**: `.claude/skills/anaconda-playwright-utils/references/assertions.md` - visibility, text, value, attribute, page URL/title, soft assertions
+- **Full API**: `.claude/skills/anaconda-playwright-utils/SKILL.md` - complete function signatures and CLI-to-library mapping
+
+### Test Patterns
+
+- **Always wrap tests in a `test.describe` block** — every spec file must have exactly one top-level `test.describe` containing all its tests
+- Use `test.describe.configure({ mode: 'parallel' });` for parallel execution within a spec
+- Use `test.beforeEach` for navigation setup
+- Use tags like `@smoke`, `@reg` in describe/test names for filtering
+- Use `clickAndNavigate()` when a click triggers page navigation; `click()` for AJAX/same-page actions
+
+## Common Commands
+
+```bash
+# Run all tests
+npm run test
+
+# Run in chromium headless
+npm run test:chromium -- <spec-file>
+
+# Run in chromium headed (visible browser)
+npm run test:chromium-headed -- <spec-file>
+
+# Run specific test by name
+npm run test:chromium-headed -- -g 'test name'
+
+# Run smoke tests
+npm run test:smoke
+
+# Run with retries and workers
+npm run test:chromium -- <spec-file> -j 3 --retries 2
+
+# View HTML report
+npm run report
+
+# Lint
+npm run lint
+npm run lint:fix
+
+# Format
+npm run format
+
+# UI mode
+npm run ui
+
+# Record tests with codegen
+npm run record
+```
+
+## Configuration
+
+- **Playwright config**: `playwright.config.ts` - projects: `setup`, `chromium` (headed), `chromiumheadless`
+- **TypeScript**: `tsconfig.json` - strict mode, ES6 target, CommonJS modules
+- **ESLint**: `eslint.config.js` - extends `@anaconda/playwright-utils/eslint` shared config (flat config format)
+- **Husky**: Pre-commit hooks for lint-staged (ESLint + Prettier)
+- **Timeouts**: Imported from `@anaconda/playwright-utils` (`TEST_TIMEOUT`, `EXPECT_TIMEOUT`, `ACTION_TIMEOUT`, `NAVIGATION_TIMEOUT`)
+
+## AI Skills and Agents
+
+This project includes AI skills and agent workflows in `.claude/` for automated test development. Cursor rules in `.cursor/rules/` reference the same skills and agents via `@file` directives, so both Claude Code and Cursor share the same knowledge base.
+
+### Cursor IDE: always include `.cursor/` with `.claude/skills/`
+
+When you use **Cursor** for test generation, refactors, or any task that relies on **skills under `.claude/`** (i.e. **`@.claude/skills/`** and every skill inside it), **always add `@.cursor/` in the same context**—for example **`@.cursor`**, **`@.cursor/rules/`**, or the relevant **`.mdc`** rule files. That pairing should be the default for **all** skills in **`@.claude/skills/`**, not only one folder.
+
+**`.claude/skills/`** holds the detailed references and workflows for each skill; **`.cursor/rules/`** maps them onto _this_ repository (globs, conventions, `@file` links into the same skill docs, and project-wide guidance such as **`project.mdc`** → this **`CLAUDE.md`**). Using **skills plus Cursor rules together** typically yields better-aligned output than either alone.
+
+**Install/update skills and agents**: `npx anaconda-pw-setup` (or `--skills` / `--agents` individually, `--force` to update, `--force-claude` to update CLAUDE.md)
+
+### Skills (`.claude/skills/`)
+
+- **anaconda-playwright-utils**: Complete API reference for all 6 utility modules. **Always reference this skill** when writing or modifying test code.
+  - **SKILL.md** — Quick reference tables with all 103 functions, import patterns, example test, CLI-to-library mapping (38 common translations)
+  - **references/actions.md** — Action functions for user interactions
+    - Click actions: click, clickAndNavigate, doubleClick, clickByJS
+    - Input actions: fill, fillAndEnter, fillAndTab, pressSequentially, clear, clearByJS
+    - Selection: selectByValue, selectByText, selectByIndex
+    - Other: check, uncheck, hover, focus, dragAndDrop, uploadFiles, downloadFile
+    - Alerts: acceptAlert, dismissAlert, getAlertText
+  - **references/assertions.md** — Assertion functions for test validation
+    - Element state: expectElementToBeVisible, expectElementToBeHidden, expectElementToBeAttached, expectElementToBeChecked, expectElementToBeEnabled, expectElementToBeDisabled, expectElementToBeEditable
+    - Text: expectElementToHaveText, expectElementToContainText
+    - Value: expectElementToHaveValue, expectElementValueToBeEmpty
+    - Attribute: expectElementToHaveAttribute, expectElementToContainAttribute
+    - Count: expectElementToHaveCount
+    - Page: expectPageToHaveURL, expectPageToContainURL, expectPageToHaveTitle
+    - Soft assertions: Pass `{ soft: true }` option, call `assertAllSoftAssertions(testInfo)` at end
+    - **Best practice:** Use assertions ONLY in page objects (verify\* methods), NOT in spec files
+  - **references/locators.md** — Locator strategy and finding elements
+    - **Locator priority** (9 tiers, best to worst): (1) data-qa-id → (2) data-testid/data-\* → (3) id → (4) name → (5) XPath with unique attrs → (6) CSS with unique attrs → (7) Playwright built-in locators (role/text) → (8) XPath structural → (9) CSS structural
+    - Functions: getLocator, getVisibleLocator, getLocatorByTestId, getLocatorByText, getLocatorByRole, getLocatorByLabel, getLocatorByPlaceholder, getAllLocators
+    - Frame functions: getFrame, getFrameLocator, getLocatorInFrame
+    - **Key concept:** Visible by default (`onlyVisible: true`)
+  - **references/element-utils.md** — Element data retrieval, state checks, and waits (16 functions)
+    - **Data retrieval**: getText, getAllTexts, getInputValue, getAllInputValues, getAttribute, getLocatorCount
+    - **Conditional checks** (return boolean): isElementAttached, isElementVisible, isElementHidden, isElementChecked
+    - **Wait functions**: waitForElementToBeVisible, waitForElementToBeHidden, waitForElementToBeAttached, waitForElementToBeDetached, waitForElementToBeStable, waitForFirstElementToBeAttached
+    - **Critical:** Use element-utils for data extraction and conditionals, NOT for assertions. Use assert-utils for assertions.
+  - **references/api-utils.md** — API request functions for HTTP testing
+    - Functions: getAPIRequestContext, getRequest, postRequest, putRequest, patchRequest, deleteRequest
+    - Returns Playwright's APIResponse object (methods: ok(), status(), json(), text(), headers())
+    - Uses page's request context (shares cookies/storage with browser)
+    - Common patterns: authentication headers, JSON/form data, response validation
+  - **references/page-utils.md** — Page management, navigation, and multi-tab handling
+    - **Singleton pattern**: getPage, setPage, getContext (setPage called automatically by fixture)
+    - **Multi-tab**: getAllPages, switchPage (1-based index), switchToDefaultPage, closePage
+    - **Navigation**: gotoURL, getURL, waitForPageLoadState, reloadPage, goBack
+    - **Utilities**: wait (use sparingly), getWindowSize, saveStorageState
+  - **references/browser-strategy.md** — Token optimization strategy for page exploration
+    - **Tier 1 (Lite):** WebFetch - 200-1000 tokens, static HTML reconnaissance
+    - **Tier 2 (Snapshot):** playwright-cli snapshot - 500-2000 tokens, interactive discovery with DOM snapshots
+    - **Tier 3 (Full Browser):** playwright-cli actions - 50-200 tokens per action, real browser interaction for selector capture
+    - **Decision rules:** Start with Lite, escalate to Snapshot if dynamic content, escalate to Full if interactive exploration needed
+
+- **playwright-cli**: Browser automation CLI for interactive page exploration, snapshots, form filling, screenshots, and debugging. Use `playwright-cli` commands to explore a page before writing tests.
+
+**Skill usage rules:**
+
+1. **Always reference `anaconda-playwright-utils` skill** when generating or modifying test code
+2. **Use specific reference files** for detailed function signatures and usage patterns:
+   - Writing actions → reference `actions.md`
+   - Writing assertions → reference `assertions.md`
+   - Finding elements → reference `locators.md`
+   - Reading element data or conditionals → reference `element-utils.md`
+   - API testing → reference `api-utils.md`
+   - Navigation or multi-tab → reference `page-utils.md`
+3. **Follow locator strategy** from `locators.md` (9-tier priority, prefer data-qa-id over role/text)
+4. **Apply browser strategy** from `browser-strategy.md` when exploring pages (start with WebFetch, escalate as needed)
+5. **Element-utils vs assert-utils distinction:**
+   - element-utils → Data extraction, conditionals (if/while), variable assignments
+   - assert-utils → Test assertions (expect\*), only in page objects not spec files
+6. **Page-utils for multi-tab:** Use switchPage with 1-based index, always switch after opening new tabs
+7. **API-utils for HTTP:** Shares page request context, use for API validation in UI tests
+8. **CLI-to-library mapping:** Translate playwright-cli generated code using SKILL.md mapping table (38 common patterns)
+
+### Agents (`.claude/agents/`)
+
+All agents follow the browser strategy in `.claude/skills/anaconda-playwright-utils/references/browser-strategy.md` and use `@anaconda/playwright-utils` functions when writing test code.
+
+- **playwright-test-planner**: Explores a web application (WebFetch first, then playwright-cli for interactive discovery) and creates comprehensive test plans in `specs/` directory with steps mapped to `@anaconda/playwright-utils` functions.
+- **playwright-test-generator**: Generates Playwright test code from test plans or from a prompt/URL. Uses playwright-cli to capture real selectors, translates to `@anaconda/playwright-utils` functions. Generated tests should follow this project's class-based POM and fixture conventions.
+- **playwright-test-healer**: Debugs and fixes failing Playwright tests. Runs tests, analyzes errors, uses playwright-cli for live debugging, and applies fixes using `@anaconda/playwright-utils` patterns.
+
+### Workflow
+
+1. **Plan**: Use the test planner agent to explore a URL and create a test plan
+2. **Generate**: Use the test generator agent to create test code from the plan or from a URL
+3. **Heal**: Use the test healer agent to fix any failing tests

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,10 +32,6 @@
     "typeRoots": ["node_modules/@types"],
     "skipLibCheck": true
   },
-  "include": [
-    "tests/e2e/**/*.ts",
-    "tests/test-setup/**/*.ts",
-    "playwright.config.ts"
-, "tests/utils/CliUtils.ts"  ],
+  "include": ["tests/e2e/**/*.ts", "tests/test-setup/**/*.ts", "playwright.config.ts", "tests/utils/CliUtils.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Adds e2e-focused agent and editor guidance under tests/e2e/ so contributors (and coding agents) can follow consistent Playwright patterns, @anaconda/playwright-utils usage, and CLI/e2e conventions for this repo.

What’s included
tests/e2e/CLAUDE.md — Project context, layout, and workflows for working in the Playwright e2e tree.
tests/e2e/.claude/ — Claude agents (e.g. test generator / planner / healer) and skills with references for:
anaconda-playwright-utils (assertions, locators, page/element/API utils, browser strategy, etc.)
playwright-cli (test generation, tracing, storage state, session management, etc.)
tests/e2e/.cursor/rules/ — Cursor rules (.mdc) aligned with Playwright agents and anaconda-playwright-utils.
Why
Centralizes how to extend and maintain CLI + browser e2e tests, reduces drift between human and agent edits, and documents integration points with shared Anaconda Playwright utilities.