### PR TITLE
Sagemaker deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Below you will find documentation for
 * [Pydantic AI](#pydanticai)
 * [Instructor](#instructor)
 * [Panel ChatInterface](#panel)
+* [AWS Sagemaker](#sagemaker)
 
 ## Install
 
@@ -541,6 +542,94 @@ the AnacondaModelHandler supports the following keyword arguments
 * `site`: Anaconda Platform site for backends that support multiple sites, None means use default
 * `client_options`: Optional dict passed as kwargs to chat.completions.create
 * `extra_options`: Optional dict passed to `AnacondaAIClient.servers.create()`
+
+## SageMaker
+
+Deploy Anaconda AI Catalog models to AWS SageMaker real-time endpoints.
+
+```text
+pip install 'anaconda-ai[sagemaker]'
+```
+
+Requires the [anaconda-sagemaker-runtime](https://github.com/anaconda/anaconda-sagemaker-runtime)
+container image built and pushed to your ECR repository.
+
+### Python SDK
+
+```python
+from anaconda_ai.integrations.sagemaker import AnacondaModel
+import json
+
+IMAGE_URI = "<account_id>.dkr.ecr.<region>.amazonaws.com/anaconda-sagemaker-runtime:latest"
+
+model = AnacondaModel(
+    model_id="Qwen2.5-7B-Instruct/Q4_K_M",
+    image_uri=IMAGE_URI,
+)
+
+# Deploy (container downloads model from catalog at startup)
+endpoint = model.deploy(instance_type="ml.g5.2xlarge")
+
+# Invoke
+response = endpoint.invoke(
+    body=json.dumps({"messages": [{"role": "user", "content": "What is conda?"}], "max_tokens": 256}),
+    content_type="application/json",
+)
+print(json.loads(response.body))
+
+# Cleanup
+endpoint.delete()
+```
+
+For faster cold starts (~4 min vs ~6 min), pre-stage the model to S3:
+
+```python
+endpoint = model.deploy(instance_type="ml.g5.2xlarge", stage=True)
+```
+
+The `stage()` and `build()` steps can also be called explicitly:
+
+```python
+model.stage()                                          # upload GGUF to S3 via CodeBuild
+model.build()                                          # register SageMaker Model resource
+endpoint = model.deploy(instance_type="ml.g5.2xlarge") # create endpoint
+```
+
+### CLI
+
+```bash
+IMAGE_URI="<account_id>.dkr.ecr.<region>.amazonaws.com/anaconda-sagemaker-runtime:latest"
+
+# Deploy (container downloads from catalog)
+anaconda ai deploy Qwen2.5-7B-Instruct/Q4_K_M --image-uri $IMAGE_URI
+
+# Deploy with S3 staging (faster cold start)
+anaconda ai deploy Qwen2.5-7B-Instruct/Q4_K_M --image-uri $IMAGE_URI --stage
+
+# Stage a model to S3 without deploying
+anaconda ai stage Qwen2.5-7B-Instruct/Q4_K_M
+
+# List staged models
+anaconda ai stage --list
+```
+
+### llama-server tuning
+
+```python
+model = AnacondaModel(
+    model_id="Qwen2.5-7B-Instruct/Q4_K_M",
+    image_uri=IMAGE_URI,
+    ctx_size=16384,
+    parallel=8,
+    flash_attn=True,
+    cache_type_k="q8_0",
+)
+```
+
+```bash
+anaconda ai deploy Qwen2.5-7B-Instruct/Q4_K_M --image-uri $IMAGE_URI \
+    --ctx-size 16384 --parallel 8 --flash-attn --cache-type-k q8_0
+```
 
 ## Setup for development
 

--- a/README.md
+++ b/README.md
@@ -606,6 +606,9 @@ anaconda ai deploy Qwen2.5-7B-Instruct/Q4_K_M --image-uri $IMAGE_URI
 # Deploy with S3 staging (faster cold start)
 anaconda ai deploy Qwen2.5-7B-Instruct/Q4_K_M --image-uri $IMAGE_URI --stage
 
+# Register model only (no endpoint), can be combined with --stage
+anaconda ai deploy Qwen2.5-7B-Instruct/Q4_K_M --image-uri $IMAGE_URI --build-only
+
 # Stage a model to S3 without deploying
 anaconda ai stage Qwen2.5-7B-Instruct/Q4_K_M
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,14 @@ module = "sagemaker.*"
 
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
+module = "boto3.*"
+
+[[tool.mypy.overrides]]
+ignore_missing_imports = true
+module = "botocore.*"
+
+[[tool.mypy.overrides]]
+ignore_missing_imports = true
 module = "ruamel.*"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ publish = [
   "wheel"
 ]
 pydantic-ai = ["pydantic-ai>=1.50"]
-sagemaker = ["sagemaker>=2.200.0"]
+sagemaker = ["sagemaker-core>=2.0.0"]
 
 [tool.distutils.bdist_wheel]
 universal = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ anaconda = "anaconda_ai.integrations.llm"
 
 [project.optional-dependencies]
 all = [
-  "anaconda-ai[langchain,dspy,instructor,litellm,llm,llama-index,panel,pydantic-ai]"
+  "anaconda-ai[langchain,dspy,instructor,litellm,llm,llama-index,panel,pydantic-ai,sagemaker]"
 ]
 dev = [
   "mypy",
@@ -57,6 +57,7 @@ publish = [
   "wheel"
 ]
 pydantic-ai = ["pydantic-ai>=1.50"]
+sagemaker = ["sagemaker>=2.200.0"]
 
 [tool.distutils.bdist_wheel]
 universal = true
@@ -111,6 +112,10 @@ module = "llama_index.embeddings.openai.*"
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
 module = "llm.*"
+
+[[tool.mypy.overrides]]
+ignore_missing_imports = true
+module = "sagemaker.*"
 
 [[tool.mypy.overrides]]
 ignore_missing_imports = true

--- a/src/anaconda_ai/cli.py
+++ b/src/anaconda_ai/cli.py
@@ -857,6 +857,22 @@ def deploy(
     reasoning_budget: Annotated[
         Optional[int], typer.Option(help="Thinking token budget")
     ] = None,
+    # Endpoint config
+    volume_size: Annotated[
+        Optional[int], typer.Option(help="EBS volume size in GB")
+    ] = None,
+    routing_strategy: Annotated[
+        str, typer.Option(help="Traffic routing (LEAST_OUTSTANDING_REQUESTS or RANDOM)")
+    ] = "LEAST_OUTSTANDING_REQUESTS",
+    kms_key_id: Annotated[
+        Optional[str], typer.Option(help="KMS key ARN for encryption")
+    ] = None,
+    security_group_ids: Annotated[
+        Optional[str], typer.Option(help="Comma-separated security group IDs for VPC")
+    ] = None,
+    subnets: Annotated[
+        Optional[str], typer.Option(help="Comma-separated subnet IDs for VPC")
+    ] = None,
     # Standard
     site: Annotated[
         Optional[str], typer.Option("--at", help="Site defined in config")
@@ -915,11 +931,24 @@ def deploy(
   https://{region}.console.aws.amazon.com/sagemaker/home?region={region}#/models/{model_name}""")
         return
 
+    vpc = None
+    if security_group_ids and subnets:
+        from sagemaker.core.shapes.shapes import VpcConfig
+
+        vpc = VpcConfig(
+            security_group_ids=security_group_ids.split(","),
+            subnets=subnets.split(","),
+        )
+
     endpoint = sm.deploy(
         instance_type=instance_type,
         endpoint_name=endpoint_name,
         stage=stage,
         stage_bucket=bucket,
+        volume_size_in_gb=volume_size,
+        routing_strategy=routing_strategy,
+        vpc_config=vpc,
+        kms_key_id=kms_key_id,
     )
 
     ep = endpoint.endpoint_name

--- a/src/anaconda_ai/cli.py
+++ b/src/anaconda_ai/cli.py
@@ -887,12 +887,39 @@ def deploy(
         stage_bucket=bucket,
     )
 
+    ep = predictor.endpoint_name
+    region = sm._boto_session.region_name
+    profile = aws_profile or "default"
+
     if as_json:
         console.print_json(
             data={
                 "status": "success",
-                "endpoint_name": predictor.endpoint_name,
+                "endpoint_name": ep,
+                "region": region,
+                "console_url": f"https://{region}.console.aws.amazon.com/sagemaker/home?region={region}#/endpoints/{ep}",
             }
         )
     else:
-        console.print(f"[green]Success[/green] endpoint={predictor.endpoint_name}")
+        console.print(f"""\n[bold green]✓[/] Endpoint [bold]{ep}[/] InService
+
+[bold]Python:[/]
+  from sagemaker.core.resources import Endpoint
+  import boto3, json
+
+  endpoint = Endpoint.get("{ep}", session=boto3.Session(profile_name="{profile}"), region="{region}")
+  response = endpoint.invoke(
+      body=json.dumps({{"messages": [{{"role": "user", "content": "Hello"}}], "max_tokens": 256}}),
+      content_type="application/json",
+  )
+  print(json.loads(response.body))
+
+[bold]AWS CLI:[/]
+  aws sagemaker-runtime invoke-endpoint \\
+    --endpoint-name {ep} \\
+    --content-type application/json \\
+    --body '{{"messages":[{{"role":"user","content":"Hello"}}],"max_tokens":256}}' \\
+    /dev/stdout
+
+[bold]Console:[/]
+  https://{region}.console.aws.amazon.com/sagemaker/home?region={region}#/endpoints/{ep}""")

--- a/src/anaconda_ai/cli.py
+++ b/src/anaconda_ai/cli.py
@@ -807,6 +807,14 @@ def deploy(
             help="Stage model to S3 before deploying (faster cold start)",
         ),
     ] = False,
+    build_only: Annotated[
+        bool,
+        typer.Option(
+            "--build-only",
+            is_flag=True,
+            help="Register model only, do not create endpoint",
+        ),
+    ] = False,
     bucket: Annotated[Optional[str], typer.Option(help="S3 bucket for staging")] = None,
     aws_profile: Annotated[Optional[str], typer.Option(help="AWS profile name")] = None,
     # llama.cpp tuning
@@ -885,6 +893,27 @@ def deploy(
         reasoning=reasoning,
         reasoning_budget=reasoning_budget,
     )
+
+    if build_only:
+        sm_model = sm.build(stage=stage, stage_bucket=bucket)
+        model_name = sm_model.model_name
+        region = sm._boto_session.region_name
+
+        if as_json:
+            console.print_json(
+                data={
+                    "status": "success",
+                    "model_name": model_name,
+                    "region": region,
+                    "console_url": f"https://{region}.console.aws.amazon.com/sagemaker/home?region={region}#/models/{model_name}",
+                }
+            )
+        else:
+            console.print(f"""\n[bold green]✓[/] Model [bold]{model_name}[/] registered
+
+[bold]Console:[/]
+  https://{region}.console.aws.amazon.com/sagemaker/home?region={region}#/models/{model_name}""")
+        return
 
     endpoint = sm.deploy(
         instance_type=instance_type,

--- a/src/anaconda_ai/cli.py
+++ b/src/anaconda_ai/cli.py
@@ -797,7 +797,7 @@ def deploy(
     ] = "ml.g5.2xlarge",
     image_uri: Annotated[
         str, typer.Option(help="Container image ECR URI", rich_help_panel="Endpoint")
-    ] = ...,
+    ] = ...,  # type: ignore[assignment]
     endpoint_name: Annotated[
         Optional[str],
         typer.Option(

--- a/src/anaconda_ai/cli.py
+++ b/src/anaconda_ai/cli.py
@@ -880,14 +880,14 @@ def deploy(
         reasoning_budget=reasoning_budget,
     )
 
-    predictor = sm.deploy(
+    endpoint = sm.deploy(
         instance_type=instance_type,
         endpoint_name=endpoint_name,
         stage_to_s3=not no_stage,
         stage_bucket=bucket,
     )
 
-    ep = predictor.endpoint_name
+    ep = endpoint.endpoint_name
     region = sm._boto_session.region_name
     profile = aws_profile or "default"
 

--- a/src/anaconda_ai/cli.py
+++ b/src/anaconda_ai/cli.py
@@ -795,10 +795,12 @@ def deploy(
     role: Annotated[
         Optional[str], typer.Option(help="SageMaker execution role ARN")
     ] = None,
-    no_stage: Annotated[
+    stage: Annotated[
         bool,
         typer.Option(
-            "--no-stage", is_flag=True, help="Skip S3 staging, download in container"
+            "--stage",
+            is_flag=True,
+            help="Stage model to S3 before deploying (faster cold start)",
         ),
     ] = False,
     bucket: Annotated[Optional[str], typer.Option(help="S3 bucket for staging")] = None,
@@ -883,7 +885,7 @@ def deploy(
     endpoint = sm.deploy(
         instance_type=instance_type,
         endpoint_name=endpoint_name,
-        stage=not no_stage,
+        stage=stage,
         stage_bucket=bucket,
     )
 

--- a/src/anaconda_ai/cli.py
+++ b/src/anaconda_ai/cli.py
@@ -789,15 +789,24 @@ def stage(
 def deploy(
     model: str = typer.Argument(help="Model name with quantization"),
     instance_type: Annotated[
-        str, typer.Option(help="SageMaker instance type (e.g. ml.g5.2xlarge)")
+        str,
+        typer.Option(
+            help="SageMaker instance type (e.g. ml.g5.2xlarge)",
+            rich_help_panel="Endpoint",
+        ),
     ] = "ml.g5.2xlarge",
-    image_uri: Annotated[str, typer.Option(help="Container image ECR URI")] = ...,
-    # SageMaker
+    image_uri: Annotated[
+        str, typer.Option(help="Container image ECR URI", rich_help_panel="Endpoint")
+    ] = ...,
     endpoint_name: Annotated[
-        Optional[str], typer.Option(help="Endpoint name (auto-generated if omitted)")
+        Optional[str],
+        typer.Option(
+            help="Endpoint name (auto-generated if omitted)", rich_help_panel="Endpoint"
+        ),
     ] = None,
     role: Annotated[
-        Optional[str], typer.Option(help="SageMaker execution role ARN")
+        Optional[str],
+        typer.Option(help="SageMaker execution role ARN", rich_help_panel="AWS"),
     ] = None,
     stage: Annotated[
         bool,
@@ -805,6 +814,7 @@ def deploy(
             "--stage",
             is_flag=True,
             help="Stage model to S3 before deploying (faster cold start)",
+            rich_help_panel="Staging",
         ),
     ] = False,
     build_only: Annotated[
@@ -813,71 +823,131 @@ def deploy(
             "--build-only",
             is_flag=True,
             help="Register model only, do not create endpoint",
+            rich_help_panel="Endpoint",
         ),
     ] = False,
-    bucket: Annotated[Optional[str], typer.Option(help="S3 bucket for staging")] = None,
-    aws_profile: Annotated[Optional[str], typer.Option(help="AWS profile name")] = None,
-    # llama.cpp tuning
-    ctx_size: Annotated[Optional[int], typer.Option(help="Context window size")] = None,
+    bucket: Annotated[
+        Optional[str],
+        typer.Option(help="S3 bucket for staging", rich_help_panel="Staging"),
+    ] = None,
+    aws_profile: Annotated[
+        Optional[str], typer.Option(help="AWS profile name", rich_help_panel="AWS")
+    ] = None,
+    ctx_size: Annotated[
+        Optional[int],
+        typer.Option(help="Context window size", rich_help_panel="llama-server"),
+    ] = None,
     n_gpu_layers: Annotated[
-        Optional[int], typer.Option(help="GPU layers to offload")
+        Optional[int],
+        typer.Option(help="GPU layers to offload", rich_help_panel="llama-server"),
     ] = None,
     parallel: Annotated[
-        Optional[int], typer.Option(help="Parallel inference slots")
+        Optional[int],
+        typer.Option(help="Parallel inference slots", rich_help_panel="llama-server"),
     ] = None,
     flash_attn: Annotated[
         Optional[bool],
-        typer.Option("--flash-attn/--no-flash-attn", help="Flash attention"),
+        typer.Option(
+            "--flash-attn/--no-flash-attn",
+            help="Flash attention",
+            rich_help_panel="llama-server",
+        ),
     ] = None,
     cont_batching: Annotated[
         Optional[bool],
-        typer.Option("--cont-batching/--no-cont-batching", help="Continuous batching"),
+        typer.Option(
+            "--cont-batching/--no-cont-batching",
+            help="Continuous batching",
+            rich_help_panel="llama-server",
+        ),
     ] = None,
     batch_size: Annotated[
-        Optional[int], typer.Option(help="Logical batch size")
+        Optional[int],
+        typer.Option(help="Logical batch size", rich_help_panel="llama-server"),
     ] = None,
     ubatch_size: Annotated[
-        Optional[int], typer.Option(help="Physical batch size")
+        Optional[int],
+        typer.Option(help="Physical batch size", rich_help_panel="llama-server"),
     ] = None,
     cache_type_k: Annotated[
-        Optional[str], typer.Option(help="KV cache type for K (f16, q8_0, q4_0)")
+        Optional[str],
+        typer.Option(
+            help="KV cache type for K (f16, q8_0, q4_0)", rich_help_panel="llama-server"
+        ),
     ] = None,
     cache_type_v: Annotated[
-        Optional[str], typer.Option(help="KV cache type for V (f16, q8_0, q4_0)")
+        Optional[str],
+        typer.Option(
+            help="KV cache type for V (f16, q8_0, q4_0)", rich_help_panel="llama-server"
+        ),
     ] = None,
     mlock: Annotated[
-        Optional[bool], typer.Option("--mlock/--no-mlock", help="Lock model in RAM")
+        Optional[bool],
+        typer.Option(
+            "--mlock/--no-mlock",
+            help="Lock model in RAM",
+            rich_help_panel="llama-server",
+        ),
     ] = None,
     jinja: Annotated[
-        Optional[bool], typer.Option("--jinja/--no-jinja", help="Jinja template engine")
+        Optional[bool],
+        typer.Option(
+            "--jinja/--no-jinja",
+            help="Jinja template engine",
+            rich_help_panel="llama-server",
+        ),
     ] = None,
     reasoning: Annotated[
-        Optional[str], typer.Option(help="Reasoning mode (on, off, auto)")
+        Optional[str],
+        typer.Option(
+            help="Reasoning mode (on, off, auto)", rich_help_panel="llama-server"
+        ),
     ] = None,
     reasoning_budget: Annotated[
-        Optional[int], typer.Option(help="Thinking token budget")
+        Optional[int],
+        typer.Option(help="Thinking token budget", rich_help_panel="llama-server"),
     ] = None,
-    # Endpoint config
     volume_size: Annotated[
-        Optional[int], typer.Option(help="EBS volume size in GB")
+        Optional[int],
+        typer.Option(help="EBS volume size in GB", rich_help_panel="Endpoint"),
     ] = None,
     routing_strategy: Annotated[
-        str, typer.Option(help="Traffic routing (LEAST_OUTSTANDING_REQUESTS or RANDOM)")
+        str,
+        typer.Option(
+            help="Traffic routing (LEAST_OUTSTANDING_REQUESTS or RANDOM)",
+            rich_help_panel="Endpoint",
+        ),
     ] = "LEAST_OUTSTANDING_REQUESTS",
     kms_key_id: Annotated[
-        Optional[str], typer.Option(help="KMS key ARN for encryption")
+        Optional[str],
+        typer.Option(help="KMS key ARN for encryption", rich_help_panel="Endpoint"),
     ] = None,
     security_group_ids: Annotated[
-        Optional[str], typer.Option(help="Comma-separated security group IDs for VPC")
+        Optional[str],
+        typer.Option(
+            help="Comma-separated security group IDs for VPC",
+            rich_help_panel="Endpoint",
+        ),
     ] = None,
     subnets: Annotated[
-        Optional[str], typer.Option(help="Comma-separated subnet IDs for VPC")
+        Optional[str],
+        typer.Option(
+            help="Comma-separated subnet IDs for VPC", rich_help_panel="Endpoint"
+        ),
     ] = None,
-    # Standard
     site: Annotated[
-        Optional[str], typer.Option("--at", help="Site defined in config")
+        Optional[str],
+        typer.Option("--at", help="Site defined in config", rich_help_panel="Anaconda"),
     ] = None,
-    as_json: AS_JSON = False,
+    as_json: Annotated[
+        bool,
+        typer.Option(
+            "--json",
+            is_flag=True,
+            help="Print output as JSON",
+            rich_help_panel="Anaconda",
+        ),
+    ] = False,
 ) -> None:
     """Deploy a model to SageMaker"""
     try:

--- a/src/anaconda_ai/cli.py
+++ b/src/anaconda_ai/cli.py
@@ -710,6 +710,10 @@ def stage(
     list_staged: Annotated[
         bool, typer.Option("--list", is_flag=True, help="List staged models in S3")
     ] = False,
+    force: Annotated[
+        bool,
+        typer.Option("--force", is_flag=True, help="Re-upload even if already staged"),
+    ] = False,
     bucket: Annotated[Optional[str], typer.Option(help="S3 bucket override")] = None,
     aws_profile: Annotated[Optional[str], typer.Option(help="AWS profile name")] = None,
     site: Annotated[
@@ -773,7 +777,7 @@ def stage(
         raise typer.Exit(1)
 
     sm = AnacondaModel(model_id=model, site=site, aws_profile=aws_profile)
-    s3_uri = sm.stage(bucket=bucket)
+    s3_uri = sm.stage(bucket=bucket, force=force)
 
     if as_json:
         console.print_json(data={"status": "success", "s3_uri": s3_uri})

--- a/src/anaconda_ai/cli.py
+++ b/src/anaconda_ai/cli.py
@@ -979,11 +979,12 @@ def deploy(
   print(json.loads(response.body))
 
 [bold]AWS CLI:[/]
-  aws sagemaker-runtime invoke-endpoint \\
+  aws sagemaker-runtime invoke-endpoint --profile {profile} --region {region} \\
     --endpoint-name {ep} \\
     --content-type application/json \\
+    --cli-binary-format raw-in-base64-out \\
     --body '{{"messages":[{{"role":"user","content":"Hello"}}],"max_tokens":256}}' \\
-    /dev/stdout
+    /dev/stderr 1>/dev/null 2>&1
 
 [bold]Console:[/]
   https://{region}.console.aws.amazon.com/sagemaker/home?region={region}#/endpoints/{ep}""")

--- a/src/anaconda_ai/cli.py
+++ b/src/anaconda_ai/cli.py
@@ -779,3 +779,120 @@ def stage(
         console.print_json(data={"status": "success", "s3_uri": s3_uri})
     else:
         console.print(f"[green]Success[/green] {s3_uri}")
+
+
+@app.command("deploy", no_args_is_help=True)
+def deploy(
+    model: str = typer.Argument(help="Model name with quantization"),
+    instance_type: Annotated[
+        str, typer.Option(help="SageMaker instance type (e.g. ml.g5.2xlarge)")
+    ] = "ml.g5.2xlarge",
+    image_uri: Annotated[str, typer.Option(help="Container image ECR URI")] = ...,
+    # SageMaker
+    endpoint_name: Annotated[
+        Optional[str], typer.Option(help="Endpoint name (auto-generated if omitted)")
+    ] = None,
+    role: Annotated[
+        Optional[str], typer.Option(help="SageMaker execution role ARN")
+    ] = None,
+    no_stage: Annotated[
+        bool,
+        typer.Option(
+            "--no-stage", is_flag=True, help="Skip S3 staging, download in container"
+        ),
+    ] = False,
+    bucket: Annotated[Optional[str], typer.Option(help="S3 bucket for staging")] = None,
+    aws_profile: Annotated[Optional[str], typer.Option(help="AWS profile name")] = None,
+    # llama.cpp tuning
+    ctx_size: Annotated[Optional[int], typer.Option(help="Context window size")] = None,
+    n_gpu_layers: Annotated[
+        Optional[int], typer.Option(help="GPU layers to offload")
+    ] = None,
+    parallel: Annotated[
+        Optional[int], typer.Option(help="Parallel inference slots")
+    ] = None,
+    flash_attn: Annotated[
+        Optional[bool],
+        typer.Option("--flash-attn/--no-flash-attn", help="Flash attention"),
+    ] = None,
+    cont_batching: Annotated[
+        Optional[bool],
+        typer.Option("--cont-batching/--no-cont-batching", help="Continuous batching"),
+    ] = None,
+    batch_size: Annotated[
+        Optional[int], typer.Option(help="Logical batch size")
+    ] = None,
+    ubatch_size: Annotated[
+        Optional[int], typer.Option(help="Physical batch size")
+    ] = None,
+    cache_type_k: Annotated[
+        Optional[str], typer.Option(help="KV cache type for K (f16, q8_0, q4_0)")
+    ] = None,
+    cache_type_v: Annotated[
+        Optional[str], typer.Option(help="KV cache type for V (f16, q8_0, q4_0)")
+    ] = None,
+    mlock: Annotated[
+        Optional[bool], typer.Option("--mlock/--no-mlock", help="Lock model in RAM")
+    ] = None,
+    jinja: Annotated[
+        Optional[bool], typer.Option("--jinja/--no-jinja", help="Jinja template engine")
+    ] = None,
+    reasoning: Annotated[
+        Optional[str], typer.Option(help="Reasoning mode (on, off, auto)")
+    ] = None,
+    reasoning_budget: Annotated[
+        Optional[int], typer.Option(help="Thinking token budget")
+    ] = None,
+    # Standard
+    site: Annotated[
+        Optional[str], typer.Option("--at", help="Site defined in config")
+    ] = None,
+    as_json: AS_JSON = False,
+) -> None:
+    """Deploy a model to SageMaker"""
+    try:
+        from anaconda_ai.integrations.sagemaker import AnacondaModel
+    except ImportError as e:
+        console.print(
+            "[red]SageMaker integration requires the sagemaker-core package.[/] "
+            "Install with: [bold]pip install 'anaconda-ai[sagemaker]'[/]"
+        )
+        raise typer.Exit(1) from e
+
+    sm = AnacondaModel(
+        model_id=model,
+        site=site,
+        role=role,
+        image_uri=image_uri,
+        aws_profile=aws_profile,
+        ctx_size=ctx_size,
+        n_gpu_layers=n_gpu_layers,
+        parallel=parallel,
+        flash_attn=flash_attn,
+        cont_batching=cont_batching,
+        batch_size=batch_size,
+        ubatch_size=ubatch_size,
+        cache_type_k=cache_type_k,
+        cache_type_v=cache_type_v,
+        mlock=mlock,
+        jinja=jinja,
+        reasoning=reasoning,
+        reasoning_budget=reasoning_budget,
+    )
+
+    predictor = sm.deploy(
+        instance_type=instance_type,
+        endpoint_name=endpoint_name,
+        stage_to_s3=not no_stage,
+        stage_bucket=bucket,
+    )
+
+    if as_json:
+        console.print_json(
+            data={
+                "status": "success",
+                "endpoint_name": predictor.endpoint_name,
+            }
+        )
+    else:
+        console.print(f"[green]Success[/green] endpoint={predictor.endpoint_name}")

--- a/src/anaconda_ai/cli.py
+++ b/src/anaconda_ai/cli.py
@@ -883,7 +883,7 @@ def deploy(
     endpoint = sm.deploy(
         instance_type=instance_type,
         endpoint_name=endpoint_name,
-        stage_to_s3=not no_stage,
+        stage=not no_stage,
         stage_bucket=bucket,
     )
 

--- a/src/anaconda_ai/cli.py
+++ b/src/anaconda_ai/cli.py
@@ -697,3 +697,85 @@ def mcp_server(
         )
         raise typer.Exit(1) from e
     run(transport=transport, host=host, port=port)
+
+
+@app.command("stage", no_args_is_help=True)
+def stage(
+    model: Annotated[
+        Optional[str],
+        typer.Argument(
+            help="Model name with quantization (e.g. Qwen2.5-7B-Instruct/Q4_K_M)"
+        ),
+    ] = None,
+    list_staged: Annotated[
+        bool, typer.Option("--list", is_flag=True, help="List staged models in S3")
+    ] = False,
+    bucket: Annotated[Optional[str], typer.Option(help="S3 bucket override")] = None,
+    aws_profile: Annotated[Optional[str], typer.Option(help="AWS profile name")] = None,
+    site: Annotated[
+        Optional[str], typer.Option("--at", help="Site defined in config")
+    ] = None,
+    as_json: AS_JSON = False,
+) -> None:
+    """Stage a model to S3 for SageMaker deployment"""
+    try:
+        from anaconda_ai.integrations.sagemaker import (
+            AnacondaModel,
+            _resolve_stage_config,
+        )
+    except ImportError as e:
+        console.print(
+            "[red]SageMaker integration requires the sagemaker-core package.[/] "
+            "Install with: [bold]pip install 'anaconda-ai[sagemaker]'[/]"
+        )
+        raise typer.Exit(1) from e
+
+    import boto3
+
+    boto_session = boto3.Session(profile_name=aws_profile)
+
+    if list_staged:
+        cfg = _resolve_stage_config(boto_session, bucket)
+        s3 = boto_session.client("s3")
+        prefix = cfg.prefix.rstrip("/") + "/" if cfg.prefix else ""
+
+        resp = s3.list_objects_v2(Bucket=cfg.bucket, Prefix=prefix, Delimiter="/")
+        models = []
+        for common_prefix in resp.get("CommonPrefixes", []):
+            model_prefix = common_prefix["Prefix"]
+            sub = s3.list_objects_v2(Bucket=cfg.bucket, Prefix=model_prefix)
+            for obj in sub.get("Contents", []):
+                if obj["Key"].endswith(".gguf"):
+                    model_path = model_prefix[len(prefix) :].rstrip("/")
+                    size_gb = obj["Size"] / (1024**3)
+                    models.append(
+                        {
+                            "model": model_path,
+                            "size_gb": round(size_gb, 2),
+                            "s3_uri": f"s3://{cfg.bucket}/{obj['Key']}",
+                        }
+                    )
+
+        if as_json:
+            console.print_json(data=models)
+        else:
+            if not models:
+                console.print(f"No staged models in s3://{cfg.bucket}/{prefix}")
+            else:
+                table = Table("Model", "Size (GB)", "S3 URI", header_style="bold green")
+                for m in models:
+                    table.add_row(m["model"], f"{m['size_gb']:.2f}", m["s3_uri"])
+                console.print(table)
+        return
+
+    if model is None:
+        console.print("[red]Provide a model name or use --list[/]")
+        raise typer.Exit(1)
+
+    sm = AnacondaModel(model_id=model, site=site, aws_profile=aws_profile)
+    s3_uri = sm.stage(bucket=bucket)
+
+    if as_json:
+        console.print_json(data={"status": "success", "s3_uri": s3_uri})
+    else:
+        console.print(f"[green]Success[/green] {s3_uri}")

--- a/src/anaconda_ai/clients/ai_navigator.py
+++ b/src/anaconda_ai/clients/ai_navigator.py
@@ -22,7 +22,6 @@ from .base import (
     BaseVectorDb,
     VectorDbTableSchema,
     TableInfo,
-    BaseSystemPrompts,
 )
 from ..utils import find_free_port
 
@@ -225,13 +224,45 @@ class AINavigatorServer(Server):
 
 
 class AINavigatorServers(BaseServers):
+    def _build_file_uuid_index(self) -> Dict[str, str]:
+        """Build a mapping of file UUID -> QuantizedFile.identifier from the models list."""
+        index: Dict[str, str] = {}
+        for model in self.client.models.list():
+            for qf in model.quantized_files:
+                index[qf.sha256] = qf.identifier
+        return index
+
+    @staticmethod
+    def _resolve_model_file_name(
+        server_data: dict, file_uuid_index: Dict[str, str]
+    ) -> None:
+        """Replace serverConfig.modelFileName with the correct identifier if the
+        server response contains a modelFile with a known file UUID."""
+        model_file = server_data.get("modelFile")
+        if model_file is None:
+            return
+
+        file_uuid = model_file.get("id") or model_file.get("uuid")
+        if file_uuid is None:
+            return
+
+        identifier = file_uuid_index.get(str(file_uuid))
+        if identifier is None:
+            return
+
+        server_config = server_data.get("serverConfig")
+        if server_config is not None:
+            server_config["modelFileName"] = identifier
+
     def list(self) -> Sequence[AINavigatorServer]:
         res = self.client.get("api/servers")
         res.raise_for_status()
+        file_uuid_index = self._build_file_uuid_index()
         servers = []
         for s in res.json()["data"]:
             if "id" not in s:
                 continue
+            self._resolve_model_file_name(s, file_uuid_index)
             server = AINavigatorServer(**s, client=self.client)
             server._client = self.client
             if not server.is_running:
@@ -244,6 +275,8 @@ class AINavigatorServers(BaseServers):
         res.raise_for_status()
 
         data: dict = res.json()["data"]
+        file_uuid_index = self._build_file_uuid_index()
+        self._resolve_model_file_name(data, file_uuid_index)
         s = AINavigatorServer(**data, client=self.client)
         return s
 

--- a/src/anaconda_ai/config.py
+++ b/src/anaconda_ai/config.py
@@ -1,7 +1,7 @@
 import json
 from os.path import expandvars
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, Optional
 
 import platformdirs
 from pydantic import BaseModel, field_validator, field_serializer, Field
@@ -85,8 +85,19 @@ class Backends(BaseModel):
     )
 
 
+class SageMakerStageConfig(BaseModel):
+    bucket: Optional[str] = None
+    prefix: str = "anaconda-models/"
+    region: Optional[str] = None
+
+
+class Stage(BaseModel):
+    sagemaker: SageMakerStageConfig = Field(default_factory=SageMakerStageConfig)
+
+
 class AnacondaAIConfig(AnacondaBaseSettings, plugin_name="ai"):
     backends: Backends = Field(default_factory=Backends)
+    stage: Stage = Field(default_factory=Stage)
     backend: Literal["ai-catalyst", "ai-navigator", "anaconda-desktop"] = "ai-navigator"
     stop_server_on_exit: bool = True
     server_operations_timeout: int = 60

--- a/src/anaconda_ai/integrations/sagemaker.py
+++ b/src/anaconda_ai/integrations/sagemaker.py
@@ -630,12 +630,13 @@ class AnacondaModel:
         prefix: str,
         region: Optional[str] = None,
         console: Optional[Console] = None,
+        force: bool = False,
     ) -> str:
         _console = console or Console()
         resolved_region = region or self._boto_session.region_name
         key = _s3_key_for_model(prefix, self.model_id)
 
-        if self._is_staged(bucket, key, resolved_region):
+        if not force and self._is_staged(bucket, key, resolved_region):
             _console.print(f"Model already staged at s3://{bucket}/{key}")
             return key
 
@@ -660,6 +661,7 @@ class AnacondaModel:
         bucket: Optional[str] = None,
         prefix: Optional[str] = None,
         region: Optional[str] = None,
+        force: bool = False,
         console: Optional[Console] = None,
     ) -> str:
         """Explicitly stage the model to S3. Returns the S3 URI.
@@ -667,7 +669,9 @@ class AnacondaModel:
         Can be called independently of deploy() for pre-staging in CI/CD.
         """
         cfg = _resolve_stage_config(self._boto_session, bucket, prefix, region)
-        key = self._stage_model(cfg.bucket, cfg.prefix, cfg.region, console)
+        key = self._stage_model(
+            cfg.bucket, cfg.prefix, cfg.region, console, force=force
+        )
         self._staged_s3_uri = f"s3://{cfg.bucket}/{key}"
         return self._staged_s3_uri
 

--- a/src/anaconda_ai/integrations/sagemaker.py
+++ b/src/anaconda_ai/integrations/sagemaker.py
@@ -458,7 +458,7 @@ class AnacondaModel:
         # llama.cpp tuning
         env = _set_env_var(self.ctx_size, "LLAMA_ARG_CTX_SIZE", env)
         env = _set_env_var(self.n_gpu_layers, "LLAMA_ARG_N_GPU_LAYERS", env)
-        env = _set_env_var(self.parallel, "LLAMA_ARG_PARALLEL", env)
+        env = _set_env_var(self.parallel, "LLAMA_ARG_N_PARALLEL", env)
         env = _set_env_var(
             int(self.flash_attn) if self.flash_attn is not None else None,
             "LLAMA_ARG_FLASH_ATTN",
@@ -469,6 +469,27 @@ class AnacondaModel:
             "LLAMA_ARG_CONT_BATCHING",
             env,
         )
+        env = _set_env_var(self.batch_size, "LLAMA_ARG_BATCH", env)
+        env = _set_env_var(self.ubatch_size, "LLAMA_ARG_UBATCH", env)
+        env = _set_env_var(self.threads, "LLAMA_ARG_THREADS", env)
+        env = _set_env_var(self.threads_http, "LLAMA_ARG_THREADS_HTTP", env)
+        env = _set_env_var(self.cache_type_k, "LLAMA_ARG_CACHE_TYPE_K", env)
+        env = _set_env_var(self.cache_type_v, "LLAMA_ARG_CACHE_TYPE_V", env)
+        env = _set_env_var(
+            int(self.mlock) if self.mlock is not None else None,
+            "LLAMA_ARG_MLOCK",
+            env,
+        )
+
+        # llama.cpp chat
+        env = _set_env_var(self.chat_template, "LLAMA_ARG_CHAT_TEMPLATE", env)
+        env = _set_env_var(
+            int(self.jinja) if self.jinja is not None else None,
+            "LLAMA_ARG_JINJA",
+            env,
+        )
+        env = _set_env_var(self.reasoning, "LLAMA_ARG_REASONING", env)
+        env = _set_env_var(self.reasoning_budget, "LLAMA_ARG_THINK_BUDGET", env)
 
         # Container tuning
         env = _set_env_var(self.inference_timeout, "INFERENCE_TIMEOUT_SECONDS", env)

--- a/src/anaconda_ai/integrations/sagemaker.py
+++ b/src/anaconda_ai/integrations/sagemaker.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import logging
 import os
@@ -273,6 +274,25 @@ def _sanitize_name(model_id: str) -> str:
     return name.strip("-")
 
 
+def _model_config_hash(
+    image_uri: str,
+    env: Dict[str, str],
+    role: str,
+    model_data_source: Optional[ModelDataSource],
+) -> str:
+    """Deterministic short hash of the model config for reuse."""
+    data_source_str = ""
+    if model_data_source and model_data_source.s3_data_source:
+        ds = model_data_source.s3_data_source
+        data_source_str = f"{ds.s3_uri}|{ds.s3_data_type}|{ds.compression_type}"
+
+    content = json.dumps(
+        {"image": image_uri, "env": env, "role": role, "data": data_source_str},
+        sort_keys=True,
+    )
+    return hashlib.sha256(content.encode()).hexdigest()[:12]
+
+
 def _s3_key_for_model(prefix: str, model_id: str) -> str:
     prefix = prefix.rstrip("/") + "/" if prefix else ""
     return f"{prefix}{model_id}/model.gguf"
@@ -360,6 +380,18 @@ class AnacondaModel:
         parallel: Optional[int] = None,
         flash_attn: Optional[bool] = None,
         cont_batching: Optional[bool] = None,
+        batch_size: Optional[int] = None,
+        ubatch_size: Optional[int] = None,
+        threads: Optional[int] = None,
+        threads_http: Optional[int] = None,
+        cache_type_k: Optional[str] = None,
+        cache_type_v: Optional[str] = None,
+        mlock: Optional[bool] = None,
+        # llama.cpp chat
+        chat_template: Optional[str] = None,
+        jinja: Optional[bool] = None,
+        reasoning: Optional[str] = None,
+        reasoning_budget: Optional[int] = None,
         # Container tuning
         inference_timeout: Optional[int] = None,
         health_timeout: Optional[int] = None,
@@ -375,6 +407,17 @@ class AnacondaModel:
         self.parallel = parallel
         self.flash_attn = flash_attn
         self.cont_batching = cont_batching
+        self.batch_size = batch_size
+        self.ubatch_size = ubatch_size
+        self.threads = threads
+        self.threads_http = threads_http
+        self.cache_type_k = cache_type_k
+        self.cache_type_v = cache_type_v
+        self.mlock = mlock
+        self.chat_template = chat_template
+        self.jinja = jinja
+        self.reasoning = reasoning
+        self.reasoning_budget = reasoning_budget
         self.inference_timeout = inference_timeout
         self.health_timeout = health_timeout
         self.log_request_body = log_request_body
@@ -707,30 +750,40 @@ class AnacondaModel:
             if container_startup_health_check_timeout is None:
                 container_startup_health_check_timeout = 3600
 
+        config_hash = _model_config_hash(
+            self.image_uri, env, self.role, model_data_source
+        )
+        model_name = f"anaconda-{_sanitize_name(self.model_id)}-{config_hash}"
+
         if endpoint_name:
             base_name = endpoint_name
         else:
             suffix = uuid.uuid4().hex[:8]
             base_name = f"anaconda-{_sanitize_name(self.model_id)}-{suffix}"
-        model_name = f"{base_name}-model"
         config_name = f"{base_name}-config"
         ep_name = base_name
 
-        container = ContainerDefinition(
-            image=self.image_uri,
-            environment=env,
-            model_data_source=model_data_source,
-        )
-
         region = self._boto_session.region_name
-        sm_model = SageMakerModel.create(
-            model_name=model_name,
-            execution_role_arn=self.role,
-            primary_container=container,
-            tags=tags,
-            session=self._boto_session,
-            region=region,
-        )
+
+        try:
+            sm_model = SageMakerModel.get(
+                model_name, session=self._boto_session, region=region
+            )
+            logger.info("Reusing existing SageMaker model: %s", model_name)
+        except Exception:
+            container = ContainerDefinition(
+                image=self.image_uri,
+                environment=env,
+                model_data_source=model_data_source,
+            )
+            sm_model = SageMakerModel.create(
+                model_name=model_name,
+                execution_role_arn=self.role,
+                primary_container=container,
+                tags=tags,
+                session=self._boto_session,
+                region=region,
+            )
 
         variant = ProductionVariant(
             variant_name="AllTraffic",

--- a/src/anaconda_ai/integrations/sagemaker.py
+++ b/src/anaconda_ai/integrations/sagemaker.py
@@ -581,8 +581,16 @@ class AnacondaModel:
         quant = self.quantized_file
 
         overrides = [
-            {"name": "MODEL_UUID", "value": str(quant.model_uuid), "type": "PLAINTEXT"},
-            {"name": "FILE_UUID", "value": str(quant.file_uuid), "type": "PLAINTEXT"},
+            {
+                "name": "MODEL_UUID",
+                "value": str(getattr(quant, "model_uuid")),
+                "type": "PLAINTEXT",
+            },
+            {
+                "name": "FILE_UUID",
+                "value": str(getattr(quant, "file_uuid")),
+                "type": "PLAINTEXT",
+            },
             {"name": "ANACONDA_DOMAIN", "value": domain, "type": "PLAINTEXT"},
             {"name": "TARGET_BUCKET", "value": bucket, "type": "PLAINTEXT"},
             {"name": "TARGET_KEY", "value": key, "type": "PLAINTEXT"},
@@ -718,6 +726,7 @@ class AnacondaModel:
         model_data_source: Optional[ModelDataSource] = None
 
         if self.is_staged:
+            assert self._staged_s3_uri is not None
             s3_prefix = self._staged_s3_uri.rsplit("/", 1)[0] + "/"
             model_data_source = ModelDataSource(
                 s3_data_source=S3ModelDataSource(
@@ -801,6 +810,7 @@ class AnacondaModel:
 
         region = self._boto_session.region_name
 
+        assert self._built_model is not None
         variant = ProductionVariant(
             variant_name="AllTraffic",
             model_name=self._built_model.model_name,

--- a/src/anaconda_ai/integrations/sagemaker.py
+++ b/src/anaconda_ai/integrations/sagemaker.py
@@ -387,8 +387,6 @@ class AnacondaModel:
         cache_type_k: Optional[str] = None,
         cache_type_v: Optional[str] = None,
         mlock: Optional[bool] = None,
-        # llama.cpp chat
-        chat_template: Optional[str] = None,
         jinja: Optional[bool] = None,
         reasoning: Optional[str] = None,
         reasoning_budget: Optional[int] = None,
@@ -414,7 +412,6 @@ class AnacondaModel:
         self.cache_type_k = cache_type_k
         self.cache_type_v = cache_type_v
         self.mlock = mlock
-        self.chat_template = chat_template
         self.jinja = jinja
         self.reasoning = reasoning
         self.reasoning_budget = reasoning_budget
@@ -482,7 +479,6 @@ class AnacondaModel:
         )
 
         # llama.cpp chat
-        env = _set_env_var(self.chat_template, "LLAMA_ARG_CHAT_TEMPLATE", env)
         env = _set_env_var(
             int(self.jinja) if self.jinja is not None else None,
             "LLAMA_ARG_JINJA",

--- a/src/anaconda_ai/integrations/sagemaker.py
+++ b/src/anaconda_ai/integrations/sagemaker.py
@@ -1,0 +1,287 @@
+import json
+import logging
+import os
+from typing import Any, Dict, Iterator, Optional, Union
+
+import boto3
+from sagemaker.deserializers import JSONDeserializer
+from sagemaker.model import Model
+from sagemaker.predictor import Predictor
+from sagemaker.serializers import JSONSerializer
+from sagemaker.session import Session
+
+from anaconda_auth.config import AnacondaAuthConfig
+from anaconda_auth.token import TokenInfo
+
+from ..clients import AnacondaAIClient
+
+logger = logging.getLogger(__name__)
+
+# Region → ECR URI mapping. Populated as the image is published to more regions.
+# Users can always override with image_uri= on AnacondaModel.
+_IMAGE_URIS: Dict[str, str] = {
+    # "us-east-1": "123456789.dkr.ecr.us-east-1.amazonaws.com/anaconda-sagemaker-runtime:latest",
+    # "us-west-2": "123456789.dkr.ecr.us-west-2.amazonaws.com/anaconda-sagemaker-runtime:latest",
+}
+
+
+def _set_env_var(value: Optional[Any], key: str, env: Dict[str, str]) -> Dict[str, str]:
+    """Set an env var only if value is non-None and key is not already in env."""
+    if value is None:
+        return env
+    if key not in env:
+        env[key] = str(value)
+    return env
+
+
+def _resolve_api_key(
+    anaconda_api_key: Optional[str] = None,
+    site: Optional[str] = None,
+    domain: Optional[str] = None,
+) -> str:
+    """Resolve Anaconda API key: explicit param → env var → keyring via TokenInfo."""
+    if anaconda_api_key:
+        return anaconda_api_key
+
+    env_key = os.environ.get("ANACONDA_AUTH_API_KEY")
+    if env_key:
+        return env_key
+
+    config_kwargs: Dict[str, Any] = {}
+    if site is not None:
+        config_kwargs["site"] = site
+    if domain is not None:
+        config_kwargs["domain"] = domain
+
+    config = AnacondaAuthConfig(**config_kwargs)
+    token = TokenInfo.load(domain=config.domain)
+    if token.api_key:
+        return token.api_key
+
+    raise ValueError(
+        "Could not resolve Anaconda API key. Provide anaconda_api_key=, "
+        "set ANACONDA_AUTH_API_KEY, or log in with `anaconda login`."
+    )
+
+
+def _resolve_image_uri(image_uri: Optional[str], region: str) -> str:
+    """Resolve ECR image URI from region map or user override."""
+    if image_uri is not None:
+        return image_uri
+
+    uri = _IMAGE_URIS.get(region)
+    if uri is None:
+        raise ValueError(
+            f"No pre-built Anaconda SageMaker image available for region '{region}'. "
+            f"Available regions: {list(_IMAGE_URIS.keys()) or '(none yet)'}. "
+            f"Provide image_uri= to use a custom container image."
+        )
+    return uri
+
+
+def _resolve_role(role: Optional[str], sagemaker_session: Session) -> str:
+    """Resolve IAM role: explicit param → SageMaker execution role."""
+    if role is not None:
+        return role
+
+    try:
+        from sagemaker import get_execution_role
+
+        return get_execution_role(sagemaker_session=sagemaker_session)
+    except ValueError:
+        raise ValueError(
+            "Could not auto-resolve SageMaker execution role. "
+            "Pass role= explicitly or run from a SageMaker notebook/Studio environment."
+        )
+
+
+class AnacondaPredictor(Predictor):
+    """Predictor with JSON serialization for Anaconda SageMaker endpoints."""
+
+    def __init__(
+        self,
+        endpoint_name: str,
+        sagemaker_session: Optional[Session] = None,
+        serializer: Any = JSONSerializer(),
+        deserializer: Any = JSONDeserializer(),
+        component_name: Optional[str] = None,
+    ):
+        super().__init__(
+            endpoint_name,
+            sagemaker_session,
+            serializer=serializer,
+            deserializer=deserializer,
+            component_name=component_name,
+        )
+
+    def predict_stream(
+        self, data: Dict[str, Any], **kwargs: Any
+    ) -> Iterator[Dict[str, Any]]:
+        """Invoke the endpoint with streaming. Returns an iterator of parsed SSE events.
+
+        The container returns SSE when ``"stream": true`` is set in the request body.
+        This method uses SageMaker's ``invoke_endpoint_with_response_stream`` API
+        and yields each parsed JSON payload from the SSE stream.
+        """
+        data = dict(data, stream=True)
+
+        runtime = boto3.client(
+            "sagemaker-runtime",
+            region_name=self.sagemaker_session.boto_region_name,
+        )
+        response = runtime.invoke_endpoint_with_response_stream(
+            EndpointName=self.endpoint_name,
+            ContentType="application/json",
+            Body=self.serializer.serialize(data),
+            **kwargs,
+        )
+
+        for event in response["Body"]:
+            chunk = event.get("PayloadPart", {}).get("Bytes", b"")
+            if not chunk:
+                continue
+
+            for line in chunk.decode("utf-8").splitlines():
+                line = line.strip()
+                if not line or not line.startswith("data: "):
+                    continue
+
+                payload = line[len("data: ") :]
+                if payload == "[DONE]":
+                    return
+
+                try:
+                    yield json.loads(payload)
+                except json.JSONDecodeError:
+                    logger.warning("Failed to parse SSE payload: %s", payload)
+                    continue
+
+
+class AnacondaModel(Model):
+    """Deploy Anaconda AI Catalog models to SageMaker endpoints."""
+
+    def __init__(
+        self,
+        model_id: str,
+        # Auth / site
+        anaconda_api_key: Optional[str] = None,
+        site: Optional[str] = None,
+        anaconda_domain: Optional[str] = None,
+        # llama.cpp tuning
+        ctx_size: Optional[int] = None,
+        n_gpu_layers: Optional[int] = None,
+        parallel: Optional[int] = None,
+        flash_attn: Optional[bool] = None,
+        cont_batching: Optional[bool] = None,
+        # Container tuning
+        inference_timeout: Optional[int] = None,
+        health_timeout: Optional[int] = None,
+        log_request_body: Optional[bool] = None,
+        # SageMaker pass-through
+        predictor_cls: Any = AnacondaPredictor,
+        **kwargs: Any,
+    ):
+        super().__init__(predictor_cls=predictor_cls, **kwargs)
+
+        self.model_id = model_id
+        self.anaconda_api_key = anaconda_api_key
+        self.site = site
+        self.anaconda_domain = anaconda_domain
+        self.ctx_size = ctx_size
+        self.n_gpu_layers = n_gpu_layers
+        self.parallel = parallel
+        self.flash_attn = flash_attn
+        self.cont_batching = cont_batching
+        self.inference_timeout = inference_timeout
+        self.health_timeout = health_timeout
+        self.log_request_body = log_request_body
+
+        self.sagemaker_session = self.sagemaker_session or Session()
+
+        self._validate_model_id()
+        self._initialize_model()
+
+    def _validate_model_id(self) -> None:
+        """Validate model_id against the Anaconda AI Catalog."""
+        client = AnacondaAIClient(
+            site=self.site,
+            domain=self.anaconda_domain,
+            backend="ai-catalyst",
+        )
+        # Raises ValueError / ModelNotFound / QuantizedFileNotFound if invalid
+        client.models._find_quantization(self.model_id)
+
+    def _initialize_model(self) -> None:
+        """Configure env vars and resolve image URI."""
+        self.env = self._configure_environment_variables()
+
+        if self.image_uri is None:
+            region = self.sagemaker_session.boto_region_name
+            self.image_uri = _resolve_image_uri(None, region)
+
+        if self.role is None:
+            self.role = _resolve_role(None, self.sagemaker_session)
+
+    def _configure_environment_variables(self) -> Dict[str, str]:
+        env: Dict[str, str] = self.env.copy() if self.env else {}
+
+        # Required
+        resolved_key = _resolve_api_key(
+            self.anaconda_api_key, self.site, self.anaconda_domain
+        )
+        env = _set_env_var(self.model_id, "ANACONDA_MODEL_ID", env)
+        env = _set_env_var(resolved_key, "ANACONDA_AUTH_API_KEY", env)
+
+        # Optional auth
+        env = _set_env_var(self.anaconda_domain, "ANACONDA_AUTH_DOMAIN", env)
+
+        # llama.cpp tuning
+        env = _set_env_var(self.ctx_size, "LLAMA_ARG_CTX_SIZE", env)
+        env = _set_env_var(self.n_gpu_layers, "LLAMA_ARG_N_GPU_LAYERS", env)
+        env = _set_env_var(self.parallel, "LLAMA_ARG_PARALLEL", env)
+        env = _set_env_var(
+            int(self.flash_attn) if self.flash_attn is not None else None,
+            "LLAMA_ARG_FLASH_ATTN",
+            env,
+        )
+        env = _set_env_var(
+            int(self.cont_batching) if self.cont_batching is not None else None,
+            "LLAMA_ARG_CONT_BATCHING",
+            env,
+        )
+
+        # Container tuning
+        env = _set_env_var(self.inference_timeout, "INFERENCE_TIMEOUT_SECONDS", env)
+        env = _set_env_var(self.health_timeout, "HEALTH_TIMEOUT_SECONDS", env)
+        env = _set_env_var(
+            int(self.log_request_body) if self.log_request_body is not None else None,
+            "LOG_REQUEST_BODY",
+            env,
+        )
+
+        return env
+
+    def deploy(
+        self,
+        *args: Any,
+        container_startup_health_check_timeout: Optional[int] = 3600,
+        **kwargs: Any,
+    ) -> Union[AnacondaPredictor, Any]:
+        """Deploy the model to a SageMaker endpoint.
+
+        Defaults container_startup_health_check_timeout to 3600 seconds
+        to allow time for model download inside the container.
+        """
+        return super().deploy(
+            *args,
+            container_startup_health_check_timeout=container_startup_health_check_timeout,
+            **kwargs,
+        )
+
+    def compile(self, **_: Any) -> None:
+        raise NotImplementedError(
+            "AnacondaModel does not support SageMaker Neo compilation"
+        )
+
+    def transformer(self, **_: Any) -> None:
+        raise NotImplementedError("AnacondaModel does not support Batch Transform")

--- a/src/anaconda_ai/integrations/sagemaker.py
+++ b/src/anaconda_ai/integrations/sagemaker.py
@@ -677,7 +677,7 @@ class AnacondaModel:
 
     def build(
         self,
-        stage: bool = True,
+        stage: bool = False,
         stage_bucket: Optional[str] = None,
         stage_prefix: Optional[str] = None,
         model_name: Optional[str] = None,
@@ -746,7 +746,7 @@ class AnacondaModel:
         instance_type: str,
         initial_instance_count: int = 1,
         endpoint_name: Optional[str] = None,
-        stage: bool = True,
+        stage: bool = False,
         stage_bucket: Optional[str] = None,
         stage_prefix: Optional[str] = None,
         container_startup_health_check_timeout: Optional[int] = None,

--- a/src/anaconda_ai/integrations/sagemaker.py
+++ b/src/anaconda_ai/integrations/sagemaker.py
@@ -1,19 +1,29 @@
+import hashlib
 import json
 import logging
 import os
-from typing import Any, Dict, Iterator, Optional, Union
+import time
+import uuid
+from typing import Any, Dict, Iterator, NamedTuple, Optional
 
 import boto3
-from sagemaker.deserializers import JSONDeserializer
-from sagemaker.model import Model
-from sagemaker.predictor import Predictor
-from sagemaker.serializers import JSONSerializer
-from sagemaker.session import Session
+from botocore.exceptions import ClientError
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskID
+from sagemaker.core.resources import Endpoint, EndpointConfig, Model as SageMakerModel
+from sagemaker.core.shapes.shapes import (
+    ContainerDefinition,
+    ModelDataSource,
+    ProductionVariant,
+    S3ModelDataSource,
+)
 
 from anaconda_auth.config import AnacondaAuthConfig
 from anaconda_auth.token import TokenInfo
 
 from ..clients import AnacondaAIClient
+from ..clients.base import QuantizedFile
+from ..config import AnacondaAIConfig
 
 logger = logging.getLogger(__name__)
 
@@ -24,9 +34,68 @@ _IMAGE_URIS: Dict[str, str] = {
     # "us-west-2": "123456789.dkr.ecr.us-west-2.amazonaws.com/anaconda-sagemaker-runtime:latest",
 }
 
+_CODEBUILD_PROJECT_NAME = "anaconda-model-stage"
+_IAM_ROLE_NAME = "AnacondaModelStageRole"
+_SSM_API_KEY_PARAM = "/anaconda/api-key"
+
+_BUILDSPEC = """\
+version: 0.2
+env:
+  parameter-store:
+    ANACONDA_AUTH_API_KEY: /anaconda/api-key
+  variables:
+    MODEL_UUID: ""
+    FILE_UUID: ""
+    ANACONDA_DOMAIN: "anaconda.com"
+    TARGET_BUCKET: ""
+    TARGET_KEY: ""
+    EXPECTED_SIZE: ""
+    EXPECTED_SHA256: ""
+phases:
+  pre_build:
+    commands:
+      - |
+        DOWNLOAD_URL=$(curl -sfS \\
+          "https://${ANACONDA_DOMAIN}/api/ai/model/models/${MODEL_UUID}/files/${FILE_UUID}/download" \\
+          -H "Authorization: Bearer ${ANACONDA_AUTH_API_KEY}" \\
+          -H "X-Anaconda-Api-Version: 2" \\
+          | python3 -c "import sys,json; print(json.load(sys.stdin)['download_url'])")
+  build:
+    commands:
+      - echo "[STAGE] Downloading to s3://${TARGET_BUCKET}/${TARGET_KEY}"
+      - |
+        curl -fSL "$DOWNLOAD_URL" \\
+          | tee >(sha256sum > /tmp/checksum.txt) \\
+          | aws s3 cp - "s3://${TARGET_BUCKET}/${TARGET_KEY}" \\
+              --expected-size "$EXPECTED_SIZE"
+  post_build:
+    commands:
+      - ACTUAL_SHA=$(awk '{print $1}' /tmp/checksum.txt)
+      - |
+        if [ "$ACTUAL_SHA" != "$EXPECTED_SHA256" ]; then
+          echo "[STAGE] CHECKSUM MISMATCH expected=$EXPECTED_SHA256 actual=$ACTUAL_SHA"
+          aws s3 rm "s3://${TARGET_BUCKET}/${TARGET_KEY}"
+          exit 1
+        fi
+      - echo "[STAGE] Checksum verified"
+      - echo "[STAGE] COMPLETE"
+"""
+
+_CODEBUILD_ASSUME_ROLE_POLICY = json.dumps(
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"Service": "codebuild.amazonaws.com"},
+                "Action": "sts:AssumeRole",
+            }
+        ],
+    }
+)
+
 
 def _set_env_var(value: Optional[Any], key: str, env: Dict[str, str]) -> Dict[str, str]:
-    """Set an env var only if value is non-None and key is not already in env."""
     if value is None:
         return env
     if key not in env:
@@ -39,7 +108,6 @@ def _resolve_api_key(
     site: Optional[str] = None,
     domain: Optional[str] = None,
 ) -> str:
-    """Resolve Anaconda API key: explicit param → env var → keyring via TokenInfo."""
     if anaconda_api_key:
         return anaconda_api_key
 
@@ -65,7 +133,6 @@ def _resolve_api_key(
 
 
 def _resolve_image_uri(image_uri: Optional[str], region: str) -> str:
-    """Resolve ECR image URI from region map or user override."""
     if image_uri is not None:
         return image_uri
 
@@ -79,60 +146,174 @@ def _resolve_image_uri(image_uri: Optional[str], region: str) -> str:
     return uri
 
 
-def _resolve_role(role: Optional[str], sagemaker_session: Session) -> str:
-    """Resolve IAM role: explicit param → SageMaker execution role."""
+_DEFAULT_SAGEMAKER_ROLE_NAME = "AmazonSageMaker-DefaultRole"
+
+_SAGEMAKER_TRUST_POLICY = json.dumps(
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"Service": "sagemaker.amazonaws.com"},
+                "Action": "sts:AssumeRole",
+            }
+        ],
+    }
+)
+
+
+def _ensure_default_sagemaker_role(boto_session: boto3.Session) -> str:
+    iam = boto_session.client("iam")
+
+    try:
+        resp = iam.get_role(RoleName=_DEFAULT_SAGEMAKER_ROLE_NAME)
+        return resp["Role"]["Arn"]
+    except iam.exceptions.NoSuchEntityException:
+        pass
+
+    logger.warning(
+        "Creating default SageMaker execution role: %s", _DEFAULT_SAGEMAKER_ROLE_NAME
+    )
+    iam.create_role(
+        RoleName=_DEFAULT_SAGEMAKER_ROLE_NAME,
+        AssumeRolePolicyDocument=_SAGEMAKER_TRUST_POLICY,
+    )
+    iam.attach_role_policy(
+        RoleName=_DEFAULT_SAGEMAKER_ROLE_NAME,
+        PolicyArn="arn:aws:iam::aws:policy/AmazonSageMakerFullAccess",
+    )
+
+    resp = iam.get_role(RoleName=_DEFAULT_SAGEMAKER_ROLE_NAME)
+    return resp["Role"]["Arn"]
+
+
+def _resolve_role(role: Optional[str], boto_session: boto3.Session) -> str:
     if role is not None:
         return role
 
+    sts = boto_session.client("sts")
+    arn = sts.get_caller_identity()["Arn"]
+
+    # SSO and service-linked roles can't be SageMaker execution roles
+    if "aws-reserved/" in arn or "AWSReservedSSO" in arn or "AWSServiceRole" in arn:
+        return _ensure_default_sagemaker_role(boto_session)
+
+    # assumed-role → role ARN (e.g. SageMaker notebook instance)
+    if ":assumed-role/" in arn:
+        parts = arn.split("/")
+        account = arn.split(":")[4]
+        role_name = parts[-2]
+        if "aws-reserved" not in role_name:
+            return f"arn:aws:iam::{account}:role/{role_name}"
+
+    # Already a role (e.g. running in SageMaker Studio)
+    if ":role/" in arn and "aws-reserved/" not in arn:
+        return arn
+
+    return _ensure_default_sagemaker_role(boto_session)
+
+
+class _StageConfig(NamedTuple):
+    bucket: str
+    prefix: str
+    region: Optional[str]
+
+
+def _default_stage_bucket(boto_session: boto3.Session) -> str:
+    sts = boto_session.client("sts")
+    account_id = sts.get_caller_identity()["Account"]
+    return f"anaconda-model-staging-{account_id}"
+
+
+def _ensure_bucket_exists(
+    bucket: str, boto_session: boto3.Session, region: Optional[str] = None
+) -> None:
+    s3 = boto_session.client("s3", region_name=region)
     try:
-        from sagemaker import get_execution_role
+        s3.head_bucket(Bucket=bucket)
+    except ClientError as e:
+        error_code = int(e.response["Error"]["Code"])
+        if error_code == 404:
+            create_kwargs: Dict[str, Any] = {"Bucket": bucket}
+            resolved_region = region or boto_session.region_name
+            if resolved_region and resolved_region != "us-east-1":
+                create_kwargs["CreateBucketConfiguration"] = {
+                    "LocationConstraint": resolved_region
+                }
+            s3.create_bucket(**create_kwargs)
+            logger.info("Created S3 bucket: %s", bucket)
+        else:
+            raise
 
-        return get_execution_role(sagemaker_session=sagemaker_session)
-    except ValueError:
-        raise ValueError(
-            "Could not auto-resolve SageMaker execution role. "
-            "Pass role= explicitly or run from a SageMaker notebook/Studio environment."
+
+def _resolve_stage_config(
+    boto_session: boto3.Session,
+    bucket: Optional[str] = None,
+    prefix: Optional[str] = None,
+    region: Optional[str] = None,
+) -> _StageConfig:
+    ai_config = AnacondaAIConfig()
+    stage_cfg = ai_config.stage.sagemaker
+
+    resolved_bucket = bucket or stage_cfg.bucket or _default_stage_bucket(boto_session)
+    resolved_prefix = prefix or stage_cfg.prefix
+    resolved_region = region or stage_cfg.region
+
+    return _StageConfig(
+        bucket=resolved_bucket,
+        prefix=resolved_prefix,
+        region=resolved_region,
+    )
+
+
+def _sanitize_name(model_id: str) -> str:
+    """SageMaker resource names must match [a-zA-Z0-9]([\\-a-zA-Z0-9]*[a-zA-Z0-9])?"""
+    import re
+
+    name = model_id.lower()
+    name = re.sub(r"[^a-z0-9-]", "-", name)
+    name = re.sub(r"-+", "-", name)
+    return name.strip("-")
+
+
+def _s3_key_for_model(prefix: str, model_id: str) -> str:
+    prefix = prefix.rstrip("/") + "/" if prefix else ""
+    return f"{prefix}{model_id}/model.gguf"
+
+
+class AnacondaPredictor:
+    """Wraps a deployed SageMaker Endpoint for prediction."""
+
+    def __init__(self, endpoint: Endpoint, boto_session: boto3.Session):
+        self._endpoint = endpoint
+        self._boto_session = boto_session
+
+    @property
+    def endpoint_name(self) -> str:
+        return self._endpoint.endpoint_name
+
+    def predict(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        response = self._endpoint.invoke(
+            body=json.dumps(data),
+            content_type="application/json",
+            accept="application/json",
         )
-
-
-class AnacondaPredictor(Predictor):
-    """Predictor with JSON serialization for Anaconda SageMaker endpoints."""
-
-    def __init__(
-        self,
-        endpoint_name: str,
-        sagemaker_session: Optional[Session] = None,
-        serializer: Any = JSONSerializer(),
-        deserializer: Any = JSONDeserializer(),
-        component_name: Optional[str] = None,
-    ):
-        super().__init__(
-            endpoint_name,
-            sagemaker_session,
-            serializer=serializer,
-            deserializer=deserializer,
-            component_name=component_name,
-        )
+        body = response.get("Body", b"")
+        if isinstance(body, bytes):
+            return json.loads(body)
+        return json.loads(body.read())
 
     def predict_stream(
         self, data: Dict[str, Any], **kwargs: Any
     ) -> Iterator[Dict[str, Any]]:
-        """Invoke the endpoint with streaming. Returns an iterator of parsed SSE events.
-
-        The container returns SSE when ``"stream": true`` is set in the request body.
-        This method uses SageMaker's ``invoke_endpoint_with_response_stream`` API
-        and yields each parsed JSON payload from the SSE stream.
-        """
+        """Invoke with streaming. Returns an iterator of parsed SSE events."""
         data = dict(data, stream=True)
 
-        runtime = boto3.client(
-            "sagemaker-runtime",
-            region_name=self.sagemaker_session.boto_region_name,
-        )
+        runtime = self._boto_session.client("sagemaker-runtime")
         response = runtime.invoke_endpoint_with_response_stream(
             EndpointName=self.endpoint_name,
             ContentType="application/json",
-            Body=self.serializer.serialize(data),
+            Body=json.dumps(data),
             **kwargs,
         )
 
@@ -156,10 +337,16 @@ class AnacondaPredictor(Predictor):
                     logger.warning("Failed to parse SSE payload: %s", payload)
                     continue
 
+    def delete_endpoint(self) -> None:
+        self._endpoint.delete()
 
-class AnacondaModel(Model):
-    """Deploy Anaconda AI Catalog models to SageMaker endpoints."""
+    def delete_model(self) -> None:
+        model = SageMakerModel.get(self._endpoint.endpoint_name)
+        if model:
+            model.delete()
 
+
+class AnacondaModel:
     def __init__(
         self,
         model_id: str,
@@ -167,6 +354,11 @@ class AnacondaModel(Model):
         anaconda_api_key: Optional[str] = None,
         site: Optional[str] = None,
         anaconda_domain: Optional[str] = None,
+        # SageMaker
+        role: Optional[str] = None,
+        image_uri: Optional[str] = None,
+        region: Optional[str] = None,
+        aws_profile: Optional[str] = None,
         # llama.cpp tuning
         ctx_size: Optional[int] = None,
         n_gpu_layers: Optional[int] = None,
@@ -177,16 +369,12 @@ class AnacondaModel(Model):
         inference_timeout: Optional[int] = None,
         health_timeout: Optional[int] = None,
         log_request_body: Optional[bool] = None,
-        # SageMaker pass-through
-        predictor_cls: Any = AnacondaPredictor,
-        **kwargs: Any,
     ):
-        super().__init__(predictor_cls=predictor_cls, **kwargs)
-
         self.model_id = model_id
         self.anaconda_api_key = anaconda_api_key
         self.site = site
         self.anaconda_domain = anaconda_domain
+        self.region = region
         self.ctx_size = ctx_size
         self.n_gpu_layers = n_gpu_layers
         self.parallel = parallel
@@ -196,43 +384,37 @@ class AnacondaModel(Model):
         self.health_timeout = health_timeout
         self.log_request_body = log_request_body
 
-        self.sagemaker_session = self.sagemaker_session or Session()
+        self._boto_session = boto3.Session(profile_name=aws_profile, region_name=region)
+        self._quantized_file: Optional[QuantizedFile] = None
 
         self._validate_model_id()
-        self._initialize_model()
+
+        self.role = _resolve_role(role, self._boto_session)
+        self.image_uri = _resolve_image_uri(image_uri, self._boto_session.region_name)
+        self.env = self._configure_environment_variables()
+
+    @property
+    def quantized_file(self) -> QuantizedFile:
+        if self._quantized_file is None:
+            raise RuntimeError("Model ID has not been validated yet")
+        return self._quantized_file
 
     def _validate_model_id(self) -> None:
-        """Validate model_id against the Anaconda AI Catalog."""
         client = AnacondaAIClient(
             site=self.site,
             domain=self.anaconda_domain,
             backend="ai-catalyst",
         )
-        # Raises ValueError / ModelNotFound / QuantizedFileNotFound if invalid
-        client.models._find_quantization(self.model_id)
-
-    def _initialize_model(self) -> None:
-        """Configure env vars and resolve image URI."""
-        self.env = self._configure_environment_variables()
-
-        if self.image_uri is None:
-            region = self.sagemaker_session.boto_region_name
-            self.image_uri = _resolve_image_uri(None, region)
-
-        if self.role is None:
-            self.role = _resolve_role(None, self.sagemaker_session)
+        self._quantized_file = client.models._find_quantization(self.model_id)
 
     def _configure_environment_variables(self) -> Dict[str, str]:
-        env: Dict[str, str] = self.env.copy() if self.env else {}
+        env: Dict[str, str] = {}
 
-        # Required
         resolved_key = _resolve_api_key(
             self.anaconda_api_key, self.site, self.anaconda_domain
         )
         env = _set_env_var(self.model_id, "ANACONDA_MODEL_ID", env)
         env = _set_env_var(resolved_key, "ANACONDA_AUTH_API_KEY", env)
-
-        # Optional auth
         env = _set_env_var(self.anaconda_domain, "ANACONDA_AUTH_DOMAIN", env)
 
         # llama.cpp tuning
@@ -261,27 +443,383 @@ class AnacondaModel(Model):
 
         return env
 
+    def _build_container_def(
+        self, model_data_source: Optional[ModelDataSource] = None
+    ) -> ContainerDefinition:
+        return ContainerDefinition(
+            image=self.image_uri,
+            environment=self.env,
+            model_data_source=model_data_source,
+        )
+
+    # ------------------------------------------------------------------
+    # S3 staging
+    # ------------------------------------------------------------------
+
+    def _is_staged(self, bucket: str, key: str, region: Optional[str] = None) -> bool:
+        s3 = self._boto_session.client("s3", region_name=region)
+        try:
+            resp = s3.head_object(Bucket=bucket, Key=key)
+            remote_size = resp["ContentLength"]
+            return remote_size == self.quantized_file.size_bytes
+        except ClientError:
+            return False
+
+    def _ensure_staging_infra(
+        self,
+        region: str,
+        bucket: str,
+        api_key: str,
+        console: Console,
+    ) -> str:
+        iam = self._boto_session.client("iam", region_name=region)
+        codebuild = self._boto_session.client("codebuild", region_name=region)
+        ssm = self._boto_session.client("ssm", region_name=region)
+        sts = self._boto_session.client("sts", region_name=region)
+        account_id = sts.get_caller_identity()["Account"]
+
+        # --- IAM Role ---
+        role_arn = f"arn:aws:iam::{account_id}:role/{_IAM_ROLE_NAME}"
+        try:
+            iam.get_role(RoleName=_IAM_ROLE_NAME)
+            logger.debug("IAM role %s exists", _IAM_ROLE_NAME)
+        except iam.exceptions.NoSuchEntityException:
+            console.print(f"  Creating IAM role ({_IAM_ROLE_NAME})...")
+            iam.create_role(
+                RoleName=_IAM_ROLE_NAME,
+                AssumeRolePolicyDocument=_CODEBUILD_ASSUME_ROLE_POLICY,
+                Description="Anaconda model staging via CodeBuild",
+            )
+            iam.put_role_policy(
+                RoleName=_IAM_ROLE_NAME,
+                PolicyName="AnacondaModelStagePolicy",
+                PolicyDocument=json.dumps(
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "s3:PutObject",
+                                    "s3:GetObject",
+                                    "s3:DeleteObject",
+                                ],
+                                "Resource": f"arn:aws:s3:::{bucket}/*",
+                            },
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "logs:CreateLogGroup",
+                                    "logs:CreateLogStream",
+                                    "logs:PutLogEvents",
+                                ],
+                                "Resource": f"arn:aws:logs:{region}:{account_id}:log-group:/aws/codebuild/{_CODEBUILD_PROJECT_NAME}*",
+                            },
+                            {
+                                "Effect": "Allow",
+                                "Action": ["ssm:GetParameters"],
+                                "Resource": f"arn:aws:ssm:{region}:{account_id}:parameter{_SSM_API_KEY_PARAM}",
+                            },
+                        ],
+                    }
+                ),
+            )
+            # IAM role propagation takes a few seconds
+            time.sleep(10)
+            console.print("  IAM role created ✓")
+
+        # --- SSM Parameter ---
+        try:
+            ssm.get_parameter(Name=_SSM_API_KEY_PARAM, WithDecryption=False)
+            logger.debug("SSM parameter %s exists", _SSM_API_KEY_PARAM)
+        except ssm.exceptions.ParameterNotFound:
+            console.print(f"  Storing API key in SSM ({_SSM_API_KEY_PARAM})...")
+            ssm.put_parameter(
+                Name=_SSM_API_KEY_PARAM,
+                Value=api_key,
+                Type="SecureString",
+                Description="Anaconda API key for model staging",
+            )
+            console.print("  SSM parameter created ✓")
+
+        # --- CodeBuild Project ---
+        try:
+            codebuild.batch_get_projects(names=[_CODEBUILD_PROJECT_NAME])["projects"][0]
+            logger.debug("CodeBuild project %s exists", _CODEBUILD_PROJECT_NAME)
+        except (IndexError, KeyError):
+            console.print(
+                f"  Creating CodeBuild project ({_CODEBUILD_PROJECT_NAME})..."
+            )
+            codebuild.create_project(
+                name=_CODEBUILD_PROJECT_NAME,
+                description="Anaconda model staging — downloads from catalog, uploads to S3",
+                source={"type": "NO_SOURCE", "buildspec": _BUILDSPEC},
+                artifacts={"type": "NO_ARTIFACTS"},
+                environment={
+                    "type": "LINUX_CONTAINER",
+                    "computeType": "BUILD_GENERAL1_MEDIUM",
+                    "image": "aws/codebuild/amazonlinux2-x86_64-standard:5.0",
+                },
+                serviceRole=role_arn,
+                timeoutInMinutes=60,
+            )
+            console.print("  CodeBuild project created ✓")
+
+        return role_arn
+
+    def _start_codebuild(
+        self, bucket: str, key: str, region: Optional[str] = None
+    ) -> str:
+        codebuild = self._boto_session.client("codebuild", region_name=region)
+
+        domain = self.anaconda_domain or "anaconda.com"
+        quant = self.quantized_file
+
+        overrides = [
+            {"name": "MODEL_UUID", "value": str(quant.model_uuid), "type": "PLAINTEXT"},
+            {"name": "FILE_UUID", "value": str(quant.file_uuid), "type": "PLAINTEXT"},
+            {"name": "ANACONDA_DOMAIN", "value": domain, "type": "PLAINTEXT"},
+            {"name": "TARGET_BUCKET", "value": bucket, "type": "PLAINTEXT"},
+            {"name": "TARGET_KEY", "value": key, "type": "PLAINTEXT"},
+            {
+                "name": "EXPECTED_SIZE",
+                "value": str(quant.size_bytes),
+                "type": "PLAINTEXT",
+            },
+            {"name": "EXPECTED_SHA256", "value": quant.sha256, "type": "PLAINTEXT"},
+        ]
+
+        resp = codebuild.start_build(
+            projectName=_CODEBUILD_PROJECT_NAME,
+            environmentVariablesOverride=overrides,
+        )
+        return resp["build"]["id"]
+
+    def _poll_progress(
+        self,
+        build_id: str,
+        region: Optional[str] = None,
+        console: Optional[Console] = None,
+    ) -> None:
+        codebuild = self._boto_session.client("codebuild", region_name=region)
+        logs_client = self._boto_session.client("logs", region_name=region)
+
+        log_group = f"/aws/codebuild/{_CODEBUILD_PROJECT_NAME}"
+        # Build ID format: "project:uuid" — log stream is the uuid part
+        log_stream = build_id.split(":")[-1]
+
+        _console = console or Console()
+        size_gb = self.quantized_file.size_bytes / (1024**3)
+
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TextColumn("{task.completed:.2f}/{task.total:.2f} GB"),
+            console=_console,
+        ) as progress:
+            task: TaskID = progress.add_task(f"Staging {self.model_id}", total=size_gb)
+
+            next_token = None
+            while True:
+                build_resp = codebuild.batch_get_builds(ids=[build_id])
+                build = build_resp["builds"][0]
+                status = build["buildStatus"]
+
+                if status != "IN_PROGRESS":
+                    if status == "SUCCEEDED":
+                        progress.update(task, completed=size_gb)
+                    break
+
+                # Poll CloudWatch for [STAGE] progress lines
+                try:
+                    log_kwargs: Dict[str, Any] = {
+                        "logGroupName": log_group,
+                        "logStreamName": log_stream,
+                        "startFromHead": True,
+                    }
+                    if next_token:
+                        log_kwargs["nextToken"] = next_token
+
+                    log_resp = logs_client.get_log_events(**log_kwargs)
+                    next_token = log_resp.get("nextForwardToken")
+
+                    for event in log_resp.get("events", []):
+                        msg = event.get("message", "")
+                        if "[STAGE]" in msg:
+                            logger.debug("CodeBuild: %s", msg.strip())
+                except ClientError:
+                    pass
+
+                time.sleep(5)
+
+        if status != "SUCCEEDED":
+            raise RuntimeError(
+                f"CodeBuild staging failed with status={status}. "
+                f"Build ID: {build_id}. Check CloudWatch logs at "
+                f"{log_group}/{log_stream}"
+            )
+
+    def _verify_staged_checksum(
+        self, bucket: str, key: str, region: Optional[str] = None
+    ) -> None:
+        s3 = self._boto_session.client("s3", region_name=region)
+        resp = s3.get_object(Bucket=bucket, Key=key)
+
+        sha = hashlib.sha256()
+        for chunk in resp["Body"].iter_chunks(chunk_size=8 * 1024 * 1024):
+            sha.update(chunk)
+
+        actual = sha.hexdigest()
+        expected = self.quantized_file.sha256
+        if actual != expected:
+            s3.delete_object(Bucket=bucket, Key=key)
+            raise RuntimeError(
+                f"Checksum mismatch after staging. "
+                f"Expected {expected}, got {actual}. "
+                f"Corrupt file deleted from S3."
+            )
+
+    def _stage_model(
+        self,
+        bucket: str,
+        prefix: str,
+        region: Optional[str] = None,
+        console: Optional[Console] = None,
+    ) -> str:
+        _console = console or Console()
+        resolved_region = region or self._boto_session.region_name
+        key = _s3_key_for_model(prefix, self.model_id)
+
+        if self._is_staged(bucket, key, resolved_region):
+            _console.print(f"Model already staged at s3://{bucket}/{key}")
+            return key
+
+        _console.print(f"Checking staging infrastructure ({resolved_region})...")
+        _ensure_bucket_exists(bucket, self._boto_session, resolved_region)
+        api_key = _resolve_api_key(
+            self.anaconda_api_key, self.site, self.anaconda_domain
+        )
+        self._ensure_staging_infra(resolved_region, bucket, api_key, _console)
+
+        size_gb = self.quantized_file.size_bytes / (1024**3)
+        _console.print(f"\nStaging {self.model_id} ({size_gb:.2f} GB)")
+
+        build_id = self._start_codebuild(bucket, key, resolved_region)
+        self._poll_progress(build_id, resolved_region, _console)
+
+        _console.print("  Verifying checksum...")
+        self._verify_staged_checksum(bucket, key, resolved_region)
+        _console.print("  ✓ sha256 verified")
+
+        return key
+
+    def stage(
+        self,
+        bucket: Optional[str] = None,
+        prefix: Optional[str] = None,
+        region: Optional[str] = None,
+        console: Optional[Console] = None,
+    ) -> str:
+        """Explicitly stage the model to S3. Returns the S3 URI.
+
+        Can be called independently of deploy() for pre-staging in CI/CD.
+        """
+        cfg = _resolve_stage_config(self._boto_session, bucket, prefix, region)
+        key = self._stage_model(cfg.bucket, cfg.prefix, cfg.region, console)
+        return f"s3://{cfg.bucket}/{key}"
+
     def deploy(
         self,
-        *args: Any,
-        container_startup_health_check_timeout: Optional[int] = 3600,
+        instance_type: str,
+        initial_instance_count: int = 1,
+        endpoint_name: Optional[str] = None,
+        stage_to_s3: bool = True,
+        stage_bucket: Optional[str] = None,
+        stage_prefix: Optional[str] = None,
+        container_startup_health_check_timeout: Optional[int] = None,
+        model_data_download_timeout: Optional[int] = None,
+        wait: bool = True,
+        tags: Optional[list] = None,
         **kwargs: Any,
-    ) -> Union[AnacondaPredictor, Any]:
-        """Deploy the model to a SageMaker endpoint.
+    ) -> AnacondaPredictor:
+        env = dict(self.env)
+        model_data_source: Optional[ModelDataSource] = None
 
-        Defaults container_startup_health_check_timeout to 3600 seconds
-        to allow time for model download inside the container.
-        """
-        return super().deploy(
-            *args,
-            container_startup_health_check_timeout=container_startup_health_check_timeout,
-            **kwargs,
+        if stage_to_s3:
+            cfg = _resolve_stage_config(self._boto_session, stage_bucket, stage_prefix)
+            resolved_region = cfg.region or self._boto_session.region_name
+            key = self._stage_model(cfg.bucket, cfg.prefix, resolved_region)
+
+            # S3Prefix URI must point to the directory (trailing /) not the file
+            s3_prefix = key.rsplit("/", 1)[0] + "/"
+            model_data_source = ModelDataSource(
+                s3_data_source=S3ModelDataSource(
+                    s3_uri=f"s3://{cfg.bucket}/{s3_prefix}",
+                    s3_data_type="S3Prefix",
+                    compression_type="None",
+                )
+            )
+            # Container doesn't need catalog auth when model is preloaded
+            env.pop("ANACONDA_AUTH_API_KEY", None)
+            env.pop("ANACONDA_MODEL_ID", None)
+
+            if container_startup_health_check_timeout is None:
+                container_startup_health_check_timeout = 600
+        else:
+            if container_startup_health_check_timeout is None:
+                container_startup_health_check_timeout = 3600
+
+        suffix = uuid.uuid4().hex[:8]
+        base_name = (
+            endpoint_name or f"anaconda-{_sanitize_name(self.model_id)}-{suffix}"
+        )
+        model_name = f"{base_name}-model"
+        config_name = f"{base_name}-config"
+        ep_name = base_name
+
+        container = ContainerDefinition(
+            image=self.image_uri,
+            environment=env,
+            model_data_source=model_data_source,
         )
 
-    def compile(self, **_: Any) -> None:
-        raise NotImplementedError(
-            "AnacondaModel does not support SageMaker Neo compilation"
+        region = self._boto_session.region_name
+        sm_model = SageMakerModel.create(
+            model_name=model_name,
+            execution_role_arn=self.role,
+            primary_container=container,
+            tags=tags,
+            session=self._boto_session,
+            region=region,
         )
 
-    def transformer(self, **_: Any) -> None:
-        raise NotImplementedError("AnacondaModel does not support Batch Transform")
+        variant = ProductionVariant(
+            variant_name="AllTraffic",
+            model_name=sm_model.model_name,
+            instance_type=instance_type,
+            initial_instance_count=initial_instance_count,
+            container_startup_health_check_timeout_in_seconds=container_startup_health_check_timeout,
+            model_data_download_timeout_in_seconds=model_data_download_timeout,
+        )
+
+        EndpointConfig.create(
+            endpoint_config_name=config_name,
+            production_variants=[variant],
+            tags=tags,
+            session=self._boto_session,
+            region=region,
+        )
+
+        endpoint = Endpoint.create(
+            endpoint_name=ep_name,
+            endpoint_config_name=config_name,
+            tags=tags,
+            session=self._boto_session,
+            region=region,
+        )
+
+        if wait:
+            endpoint.wait_for_status("InService")
+
+        return AnacondaPredictor(endpoint, self._boto_session)

--- a/src/anaconda_ai/integrations/sagemaker.py
+++ b/src/anaconda_ai/integrations/sagemaker.py
@@ -1,7 +1,7 @@
-import hashlib
 import json
 import logging
 import os
+import re
 import time
 import uuid
 from typing import Any, Dict, Iterator, NamedTuple, Optional
@@ -9,7 +9,6 @@ from typing import Any, Dict, Iterator, NamedTuple, Optional
 import boto3
 from botocore.exceptions import ClientError
 from rich.console import Console
-from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskID
 from sagemaker.core.resources import Endpoint, EndpointConfig, Model as SageMakerModel
 from sagemaker.core.shapes.shapes import (
     ContainerDefinition,
@@ -222,7 +221,7 @@ class _StageConfig(NamedTuple):
 def _default_stage_bucket(boto_session: boto3.Session) -> str:
     sts = boto_session.client("sts")
     account_id = sts.get_caller_identity()["Account"]
-    return f"anaconda-model-staging-{account_id}"
+    return f"sagemaker-anaconda-staging-{account_id}"
 
 
 def _ensure_bucket_exists(
@@ -268,8 +267,6 @@ def _resolve_stage_config(
 
 def _sanitize_name(model_id: str) -> str:
     """SageMaker resource names must match [a-zA-Z0-9]([\\-a-zA-Z0-9]*[a-zA-Z0-9])?"""
-    import re
-
     name = model_id.lower()
     name = re.sub(r"[^a-z0-9-]", "-", name)
     name = re.sub(r"-+", "-", name)
@@ -298,8 +295,10 @@ class AnacondaPredictor:
             content_type="application/json",
             accept="application/json",
         )
-        body = response.get("Body", b"")
+        body = response.body
         if isinstance(body, bytes):
+            return json.loads(body)
+        if isinstance(body, str):
             return json.loads(body)
         return json.loads(body.read())
 
@@ -339,11 +338,7 @@ class AnacondaPredictor:
 
     def delete_endpoint(self) -> None:
         self._endpoint.delete()
-
-    def delete_model(self) -> None:
-        model = SageMakerModel.get(self._endpoint.endpoint_name)
-        if model:
-            model.delete()
+        self._endpoint.wait_for_delete()
 
 
 class AnacondaModel:
@@ -443,15 +438,6 @@ class AnacondaModel:
 
         return env
 
-    def _build_container_def(
-        self, model_data_source: Optional[ModelDataSource] = None
-    ) -> ContainerDefinition:
-        return ContainerDefinition(
-            image=self.image_uri,
-            environment=self.env,
-            model_data_source=model_data_source,
-        )
-
     # ------------------------------------------------------------------
     # S3 staging
     # ------------------------------------------------------------------
@@ -490,43 +476,45 @@ class AnacondaModel:
                 AssumeRolePolicyDocument=_CODEBUILD_ASSUME_ROLE_POLICY,
                 Description="Anaconda model staging via CodeBuild",
             )
-            iam.put_role_policy(
-                RoleName=_IAM_ROLE_NAME,
-                PolicyName="AnacondaModelStagePolicy",
-                PolicyDocument=json.dumps(
-                    {
-                        "Version": "2012-10-17",
-                        "Statement": [
-                            {
-                                "Effect": "Allow",
-                                "Action": [
-                                    "s3:PutObject",
-                                    "s3:GetObject",
-                                    "s3:DeleteObject",
-                                ],
-                                "Resource": f"arn:aws:s3:::{bucket}/*",
-                            },
-                            {
-                                "Effect": "Allow",
-                                "Action": [
-                                    "logs:CreateLogGroup",
-                                    "logs:CreateLogStream",
-                                    "logs:PutLogEvents",
-                                ],
-                                "Resource": f"arn:aws:logs:{region}:{account_id}:log-group:/aws/codebuild/{_CODEBUILD_PROJECT_NAME}*",
-                            },
-                            {
-                                "Effect": "Allow",
-                                "Action": ["ssm:GetParameters"],
-                                "Resource": f"arn:aws:ssm:{region}:{account_id}:parameter{_SSM_API_KEY_PARAM}",
-                            },
-                        ],
-                    }
-                ),
-            )
             # IAM role propagation takes a few seconds
             time.sleep(10)
             console.print("  IAM role created ✓")
+
+        stage_policy = json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "s3:PutObject",
+                            "s3:GetObject",
+                            "s3:DeleteObject",
+                        ],
+                        "Resource": f"arn:aws:s3:::{bucket}/*",
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "logs:CreateLogGroup",
+                            "logs:CreateLogStream",
+                            "logs:PutLogEvents",
+                        ],
+                        "Resource": f"arn:aws:logs:{region}:{account_id}:log-group:/aws/codebuild/{_CODEBUILD_PROJECT_NAME}*",
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": ["ssm:GetParameters"],
+                        "Resource": f"arn:aws:ssm:{region}:{account_id}:parameter{_SSM_API_KEY_PARAM}",
+                    },
+                ],
+            }
+        )
+        iam.put_role_policy(
+            RoleName=_IAM_ROLE_NAME,
+            PolicyName="AnacondaModelStagePolicy",
+            PolicyDocument=stage_policy,
+        )
 
         # --- SSM Parameter ---
         try:
@@ -602,82 +590,35 @@ class AnacondaModel:
         console: Optional[Console] = None,
     ) -> None:
         codebuild = self._boto_session.client("codebuild", region_name=region)
-        logs_client = self._boto_session.client("logs", region_name=region)
-
-        log_group = f"/aws/codebuild/{_CODEBUILD_PROJECT_NAME}"
-        # Build ID format: "project:uuid" — log stream is the uuid part
-        log_stream = build_id.split(":")[-1]
 
         _console = console or Console()
         size_gb = self.quantized_file.size_bytes / (1024**3)
+        status = "IN_PROGRESS"
 
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            TextColumn("{task.completed:.2f}/{task.total:.2f} GB"),
-            console=_console,
-        ) as progress:
-            task: TaskID = progress.add_task(f"Staging {self.model_id}", total=size_gb)
-
-            next_token = None
+        with _console.status(
+            f"  Staging {self.model_id} ({size_gb:.2f} GB)..."
+        ) as spinner:
             while True:
                 build_resp = codebuild.batch_get_builds(ids=[build_id])
                 build = build_resp["builds"][0]
                 status = build["buildStatus"]
+                phase = build.get("currentPhase", "QUEUED")
 
                 if status != "IN_PROGRESS":
-                    if status == "SUCCEEDED":
-                        progress.update(task, completed=size_gb)
                     break
 
-                # Poll CloudWatch for [STAGE] progress lines
-                try:
-                    log_kwargs: Dict[str, Any] = {
-                        "logGroupName": log_group,
-                        "logStreamName": log_stream,
-                        "startFromHead": True,
-                    }
-                    if next_token:
-                        log_kwargs["nextToken"] = next_token
-
-                    log_resp = logs_client.get_log_events(**log_kwargs)
-                    next_token = log_resp.get("nextForwardToken")
-
-                    for event in log_resp.get("events", []):
-                        msg = event.get("message", "")
-                        if "[STAGE]" in msg:
-                            logger.debug("CodeBuild: %s", msg.strip())
-                except ClientError:
-                    pass
-
+                spinner.update(
+                    f"  Staging {self.model_id} ({size_gb:.2f} GB) — {phase}"
+                )
                 time.sleep(5)
 
         if status != "SUCCEEDED":
+            log_group = f"/aws/codebuild/{_CODEBUILD_PROJECT_NAME}"
+            log_stream = build_id.split(":")[-1]
             raise RuntimeError(
                 f"CodeBuild staging failed with status={status}. "
                 f"Build ID: {build_id}. Check CloudWatch logs at "
                 f"{log_group}/{log_stream}"
-            )
-
-    def _verify_staged_checksum(
-        self, bucket: str, key: str, region: Optional[str] = None
-    ) -> None:
-        s3 = self._boto_session.client("s3", region_name=region)
-        resp = s3.get_object(Bucket=bucket, Key=key)
-
-        sha = hashlib.sha256()
-        for chunk in resp["Body"].iter_chunks(chunk_size=8 * 1024 * 1024):
-            sha.update(chunk)
-
-        actual = sha.hexdigest()
-        expected = self.quantized_file.sha256
-        if actual != expected:
-            s3.delete_object(Bucket=bucket, Key=key)
-            raise RuntimeError(
-                f"Checksum mismatch after staging. "
-                f"Expected {expected}, got {actual}. "
-                f"Corrupt file deleted from S3."
             )
 
     def _stage_model(
@@ -707,10 +648,7 @@ class AnacondaModel:
 
         build_id = self._start_codebuild(bucket, key, resolved_region)
         self._poll_progress(build_id, resolved_region, _console)
-
-        _console.print("  Verifying checksum...")
-        self._verify_staged_checksum(bucket, key, resolved_region)
-        _console.print("  ✓ sha256 verified")
+        _console.print("  ✓ staged")
 
         return key
 
@@ -741,7 +679,6 @@ class AnacondaModel:
         model_data_download_timeout: Optional[int] = None,
         wait: bool = True,
         tags: Optional[list] = None,
-        **kwargs: Any,
     ) -> AnacondaPredictor:
         env = dict(self.env)
         model_data_source: Optional[ModelDataSource] = None
@@ -770,10 +707,11 @@ class AnacondaModel:
             if container_startup_health_check_timeout is None:
                 container_startup_health_check_timeout = 3600
 
-        suffix = uuid.uuid4().hex[:8]
-        base_name = (
-            endpoint_name or f"anaconda-{_sanitize_name(self.model_id)}-{suffix}"
-        )
+        if endpoint_name:
+            base_name = endpoint_name
+        else:
+            suffix = uuid.uuid4().hex[:8]
+            base_name = f"anaconda-{_sanitize_name(self.model_id)}-{suffix}"
         model_name = f"{base_name}-model"
         config_name = f"{base_name}-config"
         ep_name = base_name

--- a/src/anaconda_ai/integrations/sagemaker.py
+++ b/src/anaconda_ai/integrations/sagemaker.py
@@ -5,7 +5,7 @@ import os
 import re
 import time
 import uuid
-from typing import Any, Dict, Iterator, NamedTuple, Optional
+from typing import Any, Dict, NamedTuple, Optional
 
 import boto3
 from botocore.exceptions import ClientError
@@ -296,69 +296,6 @@ def _model_config_hash(
 def _s3_key_for_model(prefix: str, model_id: str) -> str:
     prefix = prefix.rstrip("/") + "/" if prefix else ""
     return f"{prefix}{model_id}/model.gguf"
-
-
-class AnacondaPredictor:
-    """Wraps a deployed SageMaker Endpoint for prediction."""
-
-    def __init__(self, endpoint: Endpoint, boto_session: boto3.Session):
-        self._endpoint = endpoint
-        self._boto_session = boto_session
-
-    @property
-    def endpoint_name(self) -> str:
-        return self._endpoint.endpoint_name
-
-    def predict(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        response = self._endpoint.invoke(
-            body=json.dumps(data),
-            content_type="application/json",
-            accept="application/json",
-        )
-        body = response.body
-        if isinstance(body, bytes):
-            return json.loads(body)
-        if isinstance(body, str):
-            return json.loads(body)
-        return json.loads(body.read())
-
-    def predict_stream(
-        self, data: Dict[str, Any], **kwargs: Any
-    ) -> Iterator[Dict[str, Any]]:
-        """Invoke with streaming. Returns an iterator of parsed SSE events."""
-        data = dict(data, stream=True)
-
-        runtime = self._boto_session.client("sagemaker-runtime")
-        response = runtime.invoke_endpoint_with_response_stream(
-            EndpointName=self.endpoint_name,
-            ContentType="application/json",
-            Body=json.dumps(data),
-            **kwargs,
-        )
-
-        for event in response["Body"]:
-            chunk = event.get("PayloadPart", {}).get("Bytes", b"")
-            if not chunk:
-                continue
-
-            for line in chunk.decode("utf-8").splitlines():
-                line = line.strip()
-                if not line or not line.startswith("data: "):
-                    continue
-
-                payload = line[len("data: ") :]
-                if payload == "[DONE]":
-                    return
-
-                try:
-                    yield json.loads(payload)
-                except json.JSONDecodeError:
-                    logger.warning("Failed to parse SSE payload: %s", payload)
-                    continue
-
-    def delete_endpoint(self) -> None:
-        self._endpoint.delete()
-        self._endpoint.wait_for_delete()
 
 
 class AnacondaModel:
@@ -739,7 +676,7 @@ class AnacondaModel:
         model_data_download_timeout: Optional[int] = None,
         wait: bool = True,
         tags: Optional[list] = None,
-    ) -> AnacondaPredictor:
+    ) -> Endpoint:
         role = self.role or _resolve_role(None, self._boto_session)
         image_uri = self.image_uri or _resolve_image_uri(
             None, self._boto_session.region_name
@@ -833,4 +770,4 @@ class AnacondaModel:
         if wait:
             endpoint.wait_for_status("InService")
 
-        return AnacondaPredictor(endpoint, self._boto_session)
+        return endpoint

--- a/src/anaconda_ai/integrations/sagemaker.py
+++ b/src/anaconda_ai/integrations/sagemaker.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, NamedTuple, Optional
 import boto3
 from botocore.exceptions import ClientError
 from rich.console import Console
+from rich.status import Status
 from sagemaker.core.resources import Endpoint, EndpointConfig, Model as SageMakerModel
 from sagemaker.core.shapes.shapes import (
     ContainerDefinition,
@@ -358,6 +359,8 @@ class AnacondaModel:
 
         self._boto_session = boto3.Session(profile_name=aws_profile, region_name=region)
         self._quantized_file: Optional[QuantizedFile] = None
+        self._staged_s3_uri: Optional[str] = None
+        self._built_model: Optional[SageMakerModel] = None
 
         self._validate_model_id()
         self.env = self._configure_environment_variables()
@@ -378,6 +381,9 @@ class AnacondaModel:
             backend="ai-catalyst",
         )
         self._quantized_file = client.models._find_quantization(self.model_id)
+        self.model_id = (
+            f"{self._quantized_file._model.name}/{self._quantized_file.quant_method}"
+        )
 
     def _configure_environment_variables(self) -> Dict[str, str]:
         env: Dict[str, str] = {}
@@ -662,21 +668,29 @@ class AnacondaModel:
         """
         cfg = _resolve_stage_config(self._boto_session, bucket, prefix, region)
         key = self._stage_model(cfg.bucket, cfg.prefix, cfg.region, console)
-        return f"s3://{cfg.bucket}/{key}"
+        self._staged_s3_uri = f"s3://{cfg.bucket}/{key}"
+        return self._staged_s3_uri
 
-    def deploy(
+    @property
+    def is_staged(self) -> bool:
+        return self._staged_s3_uri is not None
+
+    def build(
         self,
-        instance_type: str,
-        initial_instance_count: int = 1,
-        endpoint_name: Optional[str] = None,
-        stage_to_s3: bool = True,
+        stage: bool = True,
         stage_bucket: Optional[str] = None,
         stage_prefix: Optional[str] = None,
-        container_startup_health_check_timeout: Optional[int] = None,
-        model_data_download_timeout: Optional[int] = None,
-        wait: bool = True,
+        model_name: Optional[str] = None,
         tags: Optional[list] = None,
-    ) -> Endpoint:
+    ) -> SageMakerModel:
+        """Register a deployable model in SageMaker.
+
+        If stage=True (default), stages the model to S3 first.
+        If stage=False, the container will download from the Anaconda catalog at startup.
+        """
+        if stage and not self.is_staged:
+            self.stage(bucket=stage_bucket, prefix=stage_prefix)
+
         role = self.role or _resolve_role(None, self._boto_session)
         image_uri = self.image_uri or _resolve_image_uri(
             None, self._boto_session.region_name
@@ -685,32 +699,75 @@ class AnacondaModel:
         env = dict(self.env)
         model_data_source: Optional[ModelDataSource] = None
 
-        if stage_to_s3:
-            cfg = _resolve_stage_config(self._boto_session, stage_bucket, stage_prefix)
-            resolved_region = cfg.region or self._boto_session.region_name
-            key = self._stage_model(cfg.bucket, cfg.prefix, resolved_region)
-
-            # S3Prefix URI must point to the directory (trailing /) not the file
-            s3_prefix = key.rsplit("/", 1)[0] + "/"
+        if self.is_staged:
+            s3_prefix = self._staged_s3_uri.rsplit("/", 1)[0] + "/"
             model_data_source = ModelDataSource(
                 s3_data_source=S3ModelDataSource(
-                    s3_uri=f"s3://{cfg.bucket}/{s3_prefix}",
+                    s3_uri=s3_prefix,
                     s3_data_type="S3Prefix",
                     compression_type="None",
                 )
             )
-            # Container doesn't need catalog auth when model is preloaded
             env.pop("ANACONDA_AUTH_API_KEY", None)
             env.pop("ANACONDA_MODEL_ID", None)
 
-            if container_startup_health_check_timeout is None:
-                container_startup_health_check_timeout = 600
-        else:
-            if container_startup_health_check_timeout is None:
-                container_startup_health_check_timeout = 3600
-
         config_hash = _model_config_hash(image_uri, env, role, model_data_source)
-        model_name = f"anaconda-{_sanitize_name(self.model_id)}-{config_hash}"
+        resolved_name = (
+            model_name or f"anaconda-{_sanitize_name(self.model_id)}-{config_hash}"
+        )
+
+        region = self._boto_session.region_name
+
+        try:
+            sm_model = SageMakerModel.get(
+                resolved_name, session=self._boto_session, region=region
+            )
+            logger.info("Reusing existing SageMaker model: %s", resolved_name)
+        except Exception:
+            container = ContainerDefinition(
+                image=image_uri,
+                environment=env,
+                model_data_source=model_data_source,
+            )
+            sm_model = SageMakerModel.create(
+                model_name=resolved_name,
+                execution_role_arn=role,
+                primary_container=container,
+                tags=tags,
+                session=self._boto_session,
+                region=region,
+            )
+
+        self._built_model = sm_model
+        return sm_model
+
+    def deploy(
+        self,
+        instance_type: str,
+        initial_instance_count: int = 1,
+        endpoint_name: Optional[str] = None,
+        stage: bool = True,
+        stage_bucket: Optional[str] = None,
+        stage_prefix: Optional[str] = None,
+        container_startup_health_check_timeout: Optional[int] = None,
+        model_data_download_timeout: Optional[int] = None,
+        wait: bool = True,
+        tags: Optional[list] = None,
+    ) -> Endpoint:
+        """Deploy to a SageMaker endpoint.
+
+        Calls build() automatically if not already called.
+        """
+        if self._built_model is None:
+            self.build(
+                stage=stage,
+                stage_bucket=stage_bucket,
+                stage_prefix=stage_prefix,
+                tags=tags,
+            )
+
+        if container_startup_health_check_timeout is None:
+            container_startup_health_check_timeout = 600 if self.is_staged else 3600
 
         if endpoint_name:
             base_name = endpoint_name
@@ -722,29 +779,9 @@ class AnacondaModel:
 
         region = self._boto_session.region_name
 
-        try:
-            sm_model = SageMakerModel.get(
-                model_name, session=self._boto_session, region=region
-            )
-            logger.info("Reusing existing SageMaker model: %s", model_name)
-        except Exception:
-            container = ContainerDefinition(
-                image=image_uri,
-                environment=env,
-                model_data_source=model_data_source,
-            )
-            sm_model = SageMakerModel.create(
-                model_name=model_name,
-                execution_role_arn=role,
-                primary_container=container,
-                tags=tags,
-                session=self._boto_session,
-                region=region,
-            )
-
         variant = ProductionVariant(
             variant_name="AllTraffic",
-            model_name=sm_model.model_name,
+            model_name=self._built_model.model_name,
             instance_type=instance_type,
             initial_instance_count=initial_instance_count,
             container_startup_health_check_timeout_in_seconds=container_startup_health_check_timeout,
@@ -768,6 +805,38 @@ class AnacondaModel:
         )
 
         if wait:
-            endpoint.wait_for_status("InService")
+            self._wait_for_endpoint(endpoint)
 
         return endpoint
+
+    def _wait_for_endpoint(self, endpoint: Endpoint, poll: int = 10) -> None:
+        console = Console()
+        start = time.time()
+        text = f"{endpoint.endpoint_name} (Creating)"
+
+        with Status(text, console=console) as display:
+            while True:
+                endpoint.refresh()
+                status = endpoint.endpoint_status
+                elapsed = int(time.time() - start)
+                minutes, seconds = divmod(elapsed, 60)
+
+                if status == "InService":
+                    break
+
+                if status == "Failed":
+                    reason = getattr(endpoint, "failure_reason", "unknown")
+                    raise RuntimeError(f"Endpoint failed: {reason}")
+
+                text = (
+                    f"{endpoint.endpoint_name} ({status}) ({minutes}m {seconds:02d}s)"
+                )
+                display.update(text)
+                time.sleep(poll)
+
+        elapsed = int(time.time() - start)
+        minutes, seconds = divmod(elapsed, 60)
+        console.print(
+            f"[bold green]✓[/] {endpoint.endpoint_name} (InService) ({minutes}m {seconds:02d}s)",
+            highlight=False,
+        )

--- a/src/anaconda_ai/integrations/sagemaker.py
+++ b/src/anaconda_ai/integrations/sagemaker.py
@@ -16,7 +16,9 @@ from sagemaker.core.shapes.shapes import (
     ContainerDefinition,
     ModelDataSource,
     ProductionVariant,
+    ProductionVariantRoutingConfig,
     S3ModelDataSource,
+    VpcConfig,
 )
 
 from anaconda_auth.config import AnacondaAuthConfig
@@ -755,6 +757,10 @@ class AnacondaModel:
         stage_prefix: Optional[str] = None,
         container_startup_health_check_timeout: Optional[int] = None,
         model_data_download_timeout: Optional[int] = None,
+        volume_size_in_gb: Optional[int] = None,
+        routing_strategy: str = "LEAST_OUTSTANDING_REQUESTS",
+        vpc_config: Optional[VpcConfig] = None,
+        kms_key_id: Optional[str] = None,
         wait: bool = True,
         tags: Optional[list] = None,
     ) -> Endpoint:
@@ -790,11 +796,17 @@ class AnacondaModel:
             initial_instance_count=initial_instance_count,
             container_startup_health_check_timeout_in_seconds=container_startup_health_check_timeout,
             model_data_download_timeout_in_seconds=model_data_download_timeout,
+            volume_size_in_gb=volume_size_in_gb,
+            routing_config=ProductionVariantRoutingConfig(
+                routing_strategy=routing_strategy
+            ),
         )
 
         EndpointConfig.create(
             endpoint_config_name=config_name,
             production_variants=[variant],
+            kms_key_id=kms_key_id,
+            vpc_config=vpc_config,
             tags=tags,
             session=self._boto_session,
             region=region,

--- a/src/anaconda_ai/integrations/sagemaker.py
+++ b/src/anaconda_ai/integrations/sagemaker.py
@@ -360,6 +360,18 @@ class AnacondaModel:
         self.log_request_body = log_request_body
 
         self._boto_session = boto3.Session(profile_name=aws_profile, region_name=region)
+
+        credentials = self._boto_session.get_credentials()
+        if credentials is None:
+            profile_hint = " --aws-profile <name>" if not aws_profile else ""
+            raise ValueError(
+                "No AWS credentials found. Either:\n"
+                f"  - Pass aws_profile= (or CLI:{profile_hint})\n"
+                "  - Set AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY env vars\n"
+                "  - Configure ~/.aws/credentials\n"
+                "  - Run: aws configure"
+            )
+
         self._quantized_file: Optional[QuantizedFile] = None
         self._staged_s3_uri: Optional[str] = None
         self._built_model: Optional[SageMakerModel] = None

--- a/src/anaconda_ai/integrations/sagemaker.py
+++ b/src/anaconda_ai/integrations/sagemaker.py
@@ -426,10 +426,10 @@ class AnacondaModel:
         self._quantized_file: Optional[QuantizedFile] = None
 
         self._validate_model_id()
-
-        self.role = _resolve_role(role, self._boto_session)
-        self.image_uri = _resolve_image_uri(image_uri, self._boto_session.region_name)
         self.env = self._configure_environment_variables()
+
+        self.role = role
+        self.image_uri = image_uri
 
     @property
     def quantized_file(self) -> QuantizedFile:
@@ -744,6 +744,11 @@ class AnacondaModel:
         wait: bool = True,
         tags: Optional[list] = None,
     ) -> AnacondaPredictor:
+        role = self.role or _resolve_role(None, self._boto_session)
+        image_uri = self.image_uri or _resolve_image_uri(
+            None, self._boto_session.region_name
+        )
+
         env = dict(self.env)
         model_data_source: Optional[ModelDataSource] = None
 
@@ -771,9 +776,7 @@ class AnacondaModel:
             if container_startup_health_check_timeout is None:
                 container_startup_health_check_timeout = 3600
 
-        config_hash = _model_config_hash(
-            self.image_uri, env, self.role, model_data_source
-        )
+        config_hash = _model_config_hash(image_uri, env, role, model_data_source)
         model_name = f"anaconda-{_sanitize_name(self.model_id)}-{config_hash}"
 
         if endpoint_name:
@@ -793,13 +796,13 @@ class AnacondaModel:
             logger.info("Reusing existing SageMaker model: %s", model_name)
         except Exception:
             container = ContainerDefinition(
-                image=self.image_uri,
+                image=image_uri,
                 environment=env,
                 model_data_source=model_data_source,
             )
             sm_model = SageMakerModel.create(
                 model_name=model_name,
-                execution_role_arn=self.role,
+                execution_role_arn=role,
                 primary_container=container,
                 tags=tags,
                 session=self._boto_session,


### PR DESCRIPTION
Deploy Anaconda AI Catalog models to SageMaker real-time endpoints from the SDK and CLI using and Anaconda-provided runtime image.

**SDK** (`anaconda_ai.integrations.sagemaker`)

- `AnacondaModel`: wraps the sagemaker-core v3 API (Model, EndpointConfig, Endpoint)
- `.stage()`: optional uploads GGUF to S3 via CodeBuild (auto-provisions IAM role, project, SSM)
- `.build()`: registers a deployable model in SageMaker (staged or unstaged)
- `.deploy()`: creates endpoint, waits for InService
- Deterministic model naming — same config = same model resource, no duplicates
- SSO-aware role resolution (creates AmazonSageMaker-DefaultRole when needed)
- All llama-server LLAMA_ARG_* params exposed as constructor kwargs

**CLI**

- `anaconda ai stage MODEL`: optional stage to S3, --list, --force
- `anaconda ai deploy MODEL --image-uri URI`: full deploy with --stage, --build-only
- Grouped --help panels: Endpoint, AWS, Staging, llama-server, Anaconda
- Post-deploy output shows Python, AWS CLI, and Console URL examples

**Config**

- `[plugin.ai.stage.sagemaker]` in config.toml for bucket/prefix/region defaults
- sagemaker-core>=2.0.0 (not the full sagemaker meta-package — avoids torch/onnx/mlflow)
- Bucket naming uses sagemaker-* pattern for IAM policy compatibility