### PR TITLE
Downloading collections

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,8 @@ jobs:
             conda create -n build --file ./etc/build.linux-64.lock
         - name: conda build
           run: |
-            source $CONDA/bin/activate && conda activate build
+            eval "$(conda shell.bash hook)"
+            conda activate build
             mkdir -p ./conda-bld
             VERSION=`hatch version` conda build -c ai-staging -c conda-forge -c defaults -c anaconda-cloud/label/dev --override-channels conda.recipe --output-folder ./conda-bld
         - name: Upload the build artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,10 +41,9 @@ jobs:
             conda create -n build --file ./etc/build.linux-64.lock
         - name: conda build
           run: |
-            eval "$(conda shell.bash hook)"
-            conda activate build
+            source $CONDA/bin/activate build
             mkdir -p ./conda-bld
-            VERSION=`hatch version` conda build -c ai-staging -c conda-forge -c defaults -c anaconda-cloud/label/dev --override-channels conda.recipe --output-folder ./conda-bld
+            VERSION=`hatch version` conda-build -c ai-staging -c conda-forge -c defaults -c anaconda-cloud/label/dev --override-channels conda.recipe --output-folder ./conda-bld
         - name: Upload the build artifact
           uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
           with:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ download model files, start and stop servers through the backend.
 |Command|Description|
 |-------|-----------|
 |models|Show all models or detailed information about a single model with downloaded model files indicated in bold|
-|download|Download a model file using model name and quantization|
+|download|Download a model file using model name and quantization, or download a safetensors collection with `--safetensors`|
 |launch|Launch a server for a model file|
 |servers|Show all running servers or detailed information about a single server|
 |stop|Stop a running server by id|
@@ -125,6 +125,7 @@ The `.models` attribute provides actions to list available models and download s
 |`.list()`|`List[Model]`|List all available and downloaded models|
 |`.get('<model-name>')`|`Model`|retrieve metadata about a model|
 |`.download('<model>/<quantization>')`|None|Download a model quantization file|
+|`.download_collection('<model>')`|None|Download a safetensors collection (ai-catalyst only). Accepts `format=` kwarg (default: `"safetensors"`)|
 |`.delete('<model>/<quantization>')`|None|Delete a downloaded model quantization file|
 
 The `Model` class holds metadata for each available model
@@ -136,8 +137,10 @@ The `Model` class holds metadata for each available model
 |`.num_parameters`|int|Number of parameters for the model|
 |`.trained_for`|str|Either `'sentence-similarity'` or `'text-generation'`|
 |`.context_window_size`|int|Length of the context window for the model|
-|`.quantized_files`|`List[QuantizedFile]`|List of available quantization files|
+|`.quantized_files`|`List[QuantizedFile]`|List of available GGUF quantization files|
+|`.collections`|`List[Collection]`|List of available file collections (e.g. safetensors)|
 |`.get_quantization('<method>')`|`QuantizedFile`|Retrieve metadata for a single quantization file|
+|`.get_collection('<format>')`|`Collection`|Retrieve a collection by format (default: `"safetensors"`)|
 |`.download('<method>')`|None|Direct call to download a quantization file|
 |`.delete('<method>')`|None|Delete a downloaded quantization file|
 
@@ -169,6 +172,61 @@ There are three methods to download a quantization file:
 If the model file has already been downloaded this function returns
 immediately. Otherwise a progress bar is shown showing the download
 progress.
+
+#### Collections
+
+Collections group multiple related files (safetensors weight shards, tokenizer configs, chat templates, etc.)
+into a single logical entry. Downloading a collection gives you everything needed to use the model with
+the `transformers` library.
+
+Each `Collection` object provides (ai-catalyst backend):
+
+|Attribute|Return|Description|
+|---------|------|-----------|
+|`.file_uuid`|UUID|Unique identifier for the collection|
+|`.model_uuid`|UUID|UUID of the parent model|
+|`.filename`|str|Collection name|
+|`.format`|str|Format of the collection (e.g. `"safetensors"`)|
+|`.collection_type`|str|Type of collection (e.g. `"original"`)|
+|`.file_count`|int|Number of files in the collection|
+|`.total_size_bytes`|int|Combined size of all files|
+|`.published`|bool|Whether the collection is published|
+
+##### Downloading collections
+
+Download a safetensors collection via the SDK:
+
+```python
+from anaconda_ai import AnacondaAIClient
+
+client = AnacondaAIClient(backend="ai-catalyst")
+client.models.download_collection("Qwen3-4B-Thinking-2507")
+```
+
+Or specify an output directory:
+
+```python
+client.models.download_collection("Qwen3-4B-Thinking-2507", path="./my-model")
+```
+
+The `format` kwarg defaults to `"safetensors"` and is the only supported value currently:
+
+```python
+client.models.download_collection("Qwen3-4B-Thinking-2507", format="safetensors")
+```
+
+Via the CLI:
+
+```bash
+anaconda ai download --safetensors Qwen3-4B-Thinking-2507
+anaconda ai download --safetensors Qwen3-4B-Thinking-2507 --output ./my-model
+```
+
+Files are downloaded in parallel (5 concurrent) to the current directory by default,
+or to the path specified by `--output`. The directory is created if it does not exist.
+Each file shows its own progress bar. File sizes are verified after download.
+
+Collection downloads are only supported with the `ai-catalyst` backend.
 
 ### Servers
 

--- a/src/anaconda_ai/cli.py
+++ b/src/anaconda_ai/cli.py
@@ -47,7 +47,8 @@ def _list_models(
     table = Table(
         Column("Model", no_wrap=True),
         "Params (B)",
-        "Quantizations\ndownloaded in bold\ngreen for active servers",
+        "Quantizations\ndownloaded in [bold]bold[/bold]\nserving in [green]green[/green]",
+        "Collections",
         "Trained for",
         header_style="bold green",
     )
@@ -89,15 +90,26 @@ def _list_models(
 
             quantizations.append(method)
 
-        if quantizations:
-            quants = ", ".join(quantizations)
+        collection_formats = []
+        collection_data = []
+        for coll in sorted(model.collections, key=lambda c: getattr(c, "format", "")):
+            fmt = getattr(coll, "format", "unknown")
+            collection_formats.append(fmt)
+            collection_data.append({"format": fmt})
+
+        if quantizations or collection_formats:
+            quants = ", ".join(quantizations) if quantizations else "[dim]—[/dim]"
+            colls = (
+                ", ".join(collection_formats) if collection_formats else "[dim]—[/dim]"
+            )
             parameters = f"{model.num_parameters / 1e9:8.2f}"
-            table.add_row(model.name, parameters, quants, model.trained_for)
+            table.add_row(model.name, parameters, quants, colls, model.trained_for)
             data.append(
                 {
                     "model": model.name,
                     "parameters": model.num_parameters,
                     "quantizations": quant_data,
+                    "collections": collection_data,
                     "trained_for": model.trained_for,
                 }
             )

--- a/src/anaconda_ai/cli.py
+++ b/src/anaconda_ai/cli.py
@@ -229,6 +229,11 @@ def models(
 @app.command(name="download")
 def download(
     model: str = typer.Argument(help="Model name with quantization"),
+    safetensors: bool = typer.Option(
+        False,
+        "--safetensors",
+        help="Download safetensors collection (ai-catalyst only)",
+    ),
     force: bool = typer.Option(
         False, help="Force re-download of model if already downloaded."
     ),
@@ -248,9 +253,15 @@ def download(
 ) -> None:
     """Download a model"""
     client = AnacondaAIClient(backend=backend, site=site)
-    client.models.download(
-        model, show_progress=not as_json, force=force, console=console, path=output
-    )
+
+    if safetensors:
+        client.models.download_collection(
+            model, show_progress=not as_json, force=force, console=console, path=output
+        )
+    else:
+        client.models.download(
+            model, show_progress=not as_json, force=force, console=console, path=output
+        )
 
     if as_json:
         console.print_json(data={"status": "success"})

--- a/src/anaconda_ai/clients/ai_catalyst.py
+++ b/src/anaconda_ai/clients/ai_catalyst.py
@@ -188,8 +188,8 @@ class AICatalystModel(Model):
 
     def __init__(self, client: "AICatalystClient", **data: Any) -> None:
         raw_files = data.get("quantized_files", [])
-        quants = []
-        collections = []
+        quants: list = []
+        collections: list = []
         for entry in raw_files:
             if isinstance(entry, dict):
                 if entry.get("format", "").lower() == "gguf":

--- a/src/anaconda_ai/clients/ai_catalyst.py
+++ b/src/anaconda_ai/clients/ai_catalyst.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import datetime as dt
 from functools import cached_property, lru_cache
 from pathlib import Path
@@ -7,6 +8,8 @@ from uuid import UUID
 
 import json
 import requests
+import rich.progress
+from rich.console import Console
 from pydantic import PrivateAttr, ValidationError, computed_field, BaseModel
 from requests.exceptions import HTTPError
 
@@ -20,6 +23,7 @@ from anaconda_ai.exceptions import AnacondaAIException, QuantizedFileNotFound
 
 from ..config import AnacondaAIConfig
 from .base import (
+    Collection,
     GenericClient,
     Model,
     BaseModels,
@@ -134,6 +138,24 @@ class AICatalystQuantizedFile(QuantizedFile):
         return f"/api/ai/model/models/{self.model_uuid}/files/{self.file_uuid}/download"
 
 
+class AICatalystCollection(Collection):
+    file_uuid: UUID
+    model_uuid: UUID
+    filename: str
+    format: str
+    collection_type: str
+    file_count: int
+    total_size_bytes: int
+    size_bytes: int
+    published: bool
+    is_collection: bool = True
+    _model: "AICatalystModel" = PrivateAttr()
+
+    @property
+    def collection_download_url(self) -> str:
+        return f"/api/ai/model/models/{self.model_uuid}/collections/{self.file_uuid}/download"
+
+
 class Tag(BaseModel):
     id: int
     name: str
@@ -160,10 +182,26 @@ class AICatalystModel(Model):
     groups: List[Group]
     tags: List[Tag]
     quantized_files: List[AICatalystQuantizedFile]
+    collections: List[AICatalystCollection] = []
     converted_files: List[AICatalystConvertedFiles]
     _client: "AICatalystClient" = PrivateAttr()
 
     def __init__(self, client: "AICatalystClient", **data: Any) -> None:
+        raw_files = data.get("quantized_files", [])
+        quants = []
+        collections = []
+        for entry in raw_files:
+            if isinstance(entry, dict):
+                if entry.get("format", "").lower() == "gguf":
+                    quants.append(entry)
+                else:
+                    collections.append(entry)
+            elif isinstance(entry, AICatalystCollection):
+                collections.append(entry)
+            else:
+                quants.append(entry)
+        data["quantized_files"] = quants
+        data["collections"] = collections
         super().__init__(client=client, **data)
 
 
@@ -255,6 +293,115 @@ class AICatalystModels(BaseModels):
 
     def _delete(self, model_quantization: AICatalystQuantizedFile) -> None:  # type: ignore[override]
         model_quantization.local_path.unlink()
+
+    def download_collection(
+        self,
+        model_name: str,
+        path: Optional[Union[Path, str]] = None,
+        force: bool = False,
+        show_progress: bool = True,
+        console: Optional[Console] = None,
+    ) -> None:
+        model_info = self.get(model_name)
+        collection = model_info.get_collection("safetensors")
+
+        if not isinstance(collection, AICatalystCollection):
+            raise RuntimeError("Collection is not an AICatalystCollection")
+
+        if not collection.published:
+            raise RuntimeError(f"Collection for {model_info.name} is not published")
+
+        manifest_url = collection.collection_download_url
+        res = self.client.get(manifest_url, headers={"X-Anaconda-Api-Version": "1"})
+        res.raise_for_status()
+        manifest = res.json()
+
+        files = manifest["files"]
+        if not files:
+            raise RuntimeError(
+                f"Collection manifest for {model_info.name} contains no files"
+            )
+
+        output_dir = Path(path) if path is not None else Path.cwd()
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        files_to_download = []
+        for file_entry in files:
+            dest = output_dir / file_entry["filename"]
+            if (
+                not force
+                and dest.exists()
+                and dest.stat().st_size == file_entry["size_bytes"]
+            ):
+                continue
+            files_to_download.append(file_entry)
+
+        if not files_to_download:
+            return
+
+        console_obj = Console() if console is None else console
+        progress = rich.progress.Progress(
+            rich.progress.TextColumn("[progress.description]{task.description}"),
+            rich.progress.BarColumn(),
+            rich.progress.DownloadColumn(),
+            rich.progress.TransferSpeedColumn(),
+            rich.progress.TimeRemainingColumn(elapsed_when_finished=True),
+            console=console_obj,
+            refresh_per_second=10,
+        )
+
+        task_ids = {}
+        for file_entry in files_to_download:
+            task_id = progress.add_task(
+                description=file_entry["filename"],
+                total=file_entry["size_bytes"],
+                visible=show_progress,
+            )
+            task_ids[file_entry["filename"]] = task_id
+
+        def _download_file(file_entry: Dict[str, Any]) -> None:
+            filename = file_entry["filename"]
+            download_path = file_entry["download_path"]
+            expected_size = file_entry["size_bytes"]
+            dest = output_dir / filename
+
+            url_res = self.client.get(
+                f"{download_path}?redirect=false",
+                headers={"X-Anaconda-Api-Version": "1"},
+            )
+            url_res.raise_for_status()
+            signed_url = url_res.json()["download_url"]
+
+            response = requests.get(signed_url, stream=True)
+            response.raise_for_status()
+
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            downloaded_bytes = 0
+            with open(dest, "wb") as f:
+                for chunk in response.iter_content(1024 * 1024):
+                    f.write(chunk)
+                    downloaded_bytes += len(chunk)
+                    progress.update(task_ids[filename], completed=downloaded_bytes)
+
+            actual_size = dest.stat().st_size
+            if actual_size != expected_size:
+                dest.unlink(missing_ok=True)
+                raise RuntimeError(
+                    f"Size mismatch for {filename}: expected {expected_size}, got {actual_size}"
+                )
+
+        with progress:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+                futures = {
+                    executor.submit(_download_file, entry): entry
+                    for entry in files_to_download
+                }
+                for future in concurrent.futures.as_completed(futures):
+                    exc = future.exception()
+                    if exc is not None:
+                        for f in futures:
+                            f.cancel()
+                        raise exc
 
 
 class AICatalystServerConfig(ServerConfig):

--- a/src/anaconda_ai/clients/ai_catalyst.py
+++ b/src/anaconda_ai/clients/ai_catalyst.py
@@ -301,9 +301,14 @@ class AICatalystModels(BaseModels):
         force: bool = False,
         show_progress: bool = True,
         console: Optional[Console] = None,
+        format: str = "safetensors",
     ) -> None:
+        if format != "safetensors":
+            raise ValueError(
+                f"Unsupported collection format: {format!r}. Only 'safetensors' is supported."
+            )
         model_info = self.get(model_name)
-        collection = model_info.get_collection("safetensors")
+        collection = model_info.get_collection(format)
 
         if not isinstance(collection, AICatalystCollection):
             raise RuntimeError("Collection is not an AICatalystCollection")

--- a/src/anaconda_ai/clients/ai_navigator.py
+++ b/src/anaconda_ai/clients/ai_navigator.py
@@ -149,6 +149,18 @@ class AINavigatorModels(BaseModels):
         res = self.client.delete(model_quantization._url)
         res.raise_for_status()
 
+    def download_collection(
+        self,
+        model_name: str,
+        path: Optional[Union[Path, str]] = None,
+        force: bool = False,
+        show_progress: bool = True,
+        console: Optional[Console] = None,
+    ) -> None:
+        raise NotImplementedError(
+            "Safetensors collection download is only supported with the ai-catalyst backend"
+        )
+
 
 class AINavigatorServerParams(BaseModel, extra="allow"):
     host: Optional[str] = None

--- a/src/anaconda_ai/clients/ai_navigator.py
+++ b/src/anaconda_ai/clients/ai_navigator.py
@@ -156,6 +156,7 @@ class AINavigatorModels(BaseModels):
         force: bool = False,
         show_progress: bool = True,
         console: Optional[Console] = None,
+        format: str = "safetensors",
     ) -> None:
         raise NotImplementedError(
             "Safetensors collection download is only supported with the ai-catalyst backend"

--- a/src/anaconda_ai/clients/base.py
+++ b/src/anaconda_ai/clients/base.py
@@ -326,7 +326,12 @@ class BaseModels:
         force: bool = False,
         show_progress: bool = True,
         console: Optional[Console] = None,
+        format: str = "safetensors",
     ) -> None:
+        if format != "safetensors":
+            raise ValueError(
+                f"Unsupported collection format: {format!r}. Only 'safetensors' is supported."
+            )
         raise NotImplementedError(
             "Safetensors collection download is only supported with the ai-catalyst backend"
         )

--- a/src/anaconda_ai/clients/base.py
+++ b/src/anaconda_ai/clients/base.py
@@ -198,6 +198,18 @@ class Model(BaseModel):
         quant = self.get_quantization(method)
         quant.delete()
 
+    def get_collection(self, format: str = "safetensors") -> "QuantizedFile":
+        for quant in self.quantized_files:
+            if (
+                getattr(quant, "is_collection", False)
+                and getattr(quant, "format", "").lower() == format.lower()
+                and getattr(quant, "collection_type", None) == "original"
+                and getattr(quant, "filename", None)
+                == "original-safetensors-collection"
+            ):
+                return quant
+        raise QuantizedFileNotFound(f"No {format} collection found for {self.name}.")
+
 
 class BaseModels:
     client: GenericClient
@@ -301,6 +313,18 @@ class BaseModels:
             model_quantization = self._find_quantization(model_quantization)
 
         self._delete(model_quantization)
+
+    def download_collection(
+        self,
+        model_name: str,
+        path: Optional[Union[Path, str]] = None,
+        force: bool = False,
+        show_progress: bool = True,
+        console: Optional[Console] = None,
+    ) -> None:
+        raise NotImplementedError(
+            "Safetensors collection download is only supported with the ai-catalyst backend"
+        )
 
 
 class ServerConfig(BaseModel):

--- a/src/anaconda_ai/clients/base.py
+++ b/src/anaconda_ai/clients/base.py
@@ -150,6 +150,10 @@ class QuantizedFile(BaseModel):
         self._model._client.models.delete(self)
 
 
+class Collection(BaseModel):
+    _model: "Model" = PrivateAttr()
+
+
 class Model(BaseModel):
     name: str
     description: str
@@ -157,6 +161,7 @@ class Model(BaseModel):
     trained_for: str
     context_window_size: int
     quantized_files: Sequence[QuantizedFile]
+    collections: Sequence[Collection] = []
     _client: GenericClient = PrivateAttr()
 
     def __init__(self, client: GenericClient, **data: Any) -> None:
@@ -170,6 +175,8 @@ class Model(BaseModel):
         self.quantized_files = sorted(
             self.quantized_files, key=lambda q: q.quant_method
         )
+        for coll in self.collections:
+            coll._model = self
         return self
 
     def get_quantization(self, method: str) -> QuantizedFile:
@@ -198,16 +205,14 @@ class Model(BaseModel):
         quant = self.get_quantization(method)
         quant.delete()
 
-    def get_collection(self, format: str = "safetensors") -> "QuantizedFile":
-        for quant in self.quantized_files:
+    def get_collection(self, format: str = "safetensors") -> "Collection":
+        for coll in self.collections:
             if (
-                getattr(quant, "is_collection", False)
-                and getattr(quant, "format", "").lower() == format.lower()
-                and getattr(quant, "collection_type", None) == "original"
-                and getattr(quant, "filename", None)
-                == "original-safetensors-collection"
+                getattr(coll, "format", "").lower() == format.lower()
+                and getattr(coll, "collection_type", None) == "original"
+                and getattr(coll, "filename", None) == "original-safetensors-collection"
             ):
-                return quant
+                return coll
         raise QuantizedFileNotFound(f"No {format} collection found for {self.name}.")
 
 

--- a/tests/test_download_collection.py
+++ b/tests/test_download_collection.py
@@ -1,0 +1,315 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import pytest
+from typer.testing import CliRunner
+
+from anaconda_cli_base.cli import app
+from anaconda_ai.clients.ai_catalyst import (
+    AICatalystModels,
+    AICatalystQuantizedFile,
+    AICatalystCollection,
+)
+from anaconda_ai.clients.ai_navigator import AINavigatorModels
+from anaconda_ai.exceptions import QuantizedFileNotFound
+
+
+SAMPLE_MODEL_UUID = "7106c922-eb21-4c10-b7bd-6017a58cfa2d"
+SAMPLE_FILE_UUID = "4ab4ce09-d3a9-4d67-9dce-70575d0b5d0b"
+
+SAMPLE_MANIFEST = {
+    "file_uuid": SAMPLE_FILE_UUID,
+    "model_uuid": SAMPLE_MODEL_UUID,
+    "filename": "Qwen3-4B-Thinking-2507",
+    "collection_type": "original",
+    "format": "safetensors",
+    "file_count": 2,
+    "total_size_bytes": 200,
+    "files": [
+        {
+            "filename": "model-00001-of-00002.safetensors",
+            "size_bytes": 100,
+            "sha256": "aaa",
+            "download_path": f"/models/{SAMPLE_MODEL_UUID}/collections/{SAMPLE_FILE_UUID}/download/model-00001-of-00002.safetensors",
+        },
+        {
+            "filename": "config.json",
+            "size_bytes": 100,
+            "sha256": "bbb",
+            "download_path": f"/models/{SAMPLE_MODEL_UUID}/collections/{SAMPLE_FILE_UUID}/download/config.json",
+        },
+    ],
+}
+
+
+def _make_collection() -> AICatalystCollection:
+    coll = AICatalystCollection(
+        file_uuid=UUID(SAMPLE_FILE_UUID),
+        model_uuid=UUID(SAMPLE_MODEL_UUID),
+        filename="original-safetensors-collection",
+        format="safetensors",
+        collection_type="original",
+        file_count=2,
+        total_size_bytes=200,
+        size_bytes=200,
+        published=True,
+    )
+    mock_model = MagicMock()
+    mock_model.name = "Qwen3-4B-Thinking-2507"
+    coll._model = mock_model
+    return coll
+
+
+def _make_regular_quant() -> AICatalystQuantizedFile:
+    quant = AICatalystQuantizedFile(
+        file_uuid=UUID("11111111-1111-1111-1111-111111111111"),
+        model_uuid=UUID(SAMPLE_MODEL_UUID),
+        generated_on="2026-05-19T08:45:21Z",
+        quant_engine="llama.cpp",
+        published=True,
+        context_window_size=4096,
+        sha256="abc123",
+        size_bytes=4000000,
+        quant_method="Q4_K_M",
+        format="gguf",
+        max_ram_usage=6000000,
+        is_collection=False,
+    )
+    mock_model = MagicMock()
+    mock_model.name = "Qwen3-4B-Thinking-2507"
+    quant._model = mock_model
+    return quant
+
+
+@pytest.fixture()
+def mock_catalyst_client() -> MagicMock:
+    client = MagicMock()
+    client.config = MagicMock()
+    client.config.domain = "test.anaconda.com"
+    return client
+
+
+@pytest.fixture()
+def catalyst_models(mock_catalyst_client: MagicMock) -> AICatalystModels:
+    return AICatalystModels(mock_catalyst_client)
+
+
+class TestGetCollection:
+    def test_finds_collection(self) -> None:
+        from anaconda_ai.clients.base import Model
+
+        collection = _make_collection()
+        regular_quant = _make_regular_quant()
+
+        mock_client = MagicMock()
+        mock_client.ai_config = MagicMock()
+
+        model = Model(
+            client=mock_client,
+            name="TestModel",
+            description="test",
+            num_parameters=1000,
+            trained_for="text-generation",
+            context_window_size=4096,
+            quantized_files=[regular_quant],
+            collections=[collection],
+        )
+
+        result = model.get_collection("safetensors")
+        assert result is collection
+        assert result.filename == "original-safetensors-collection"
+        assert result.collection_type == "original"
+
+    def test_no_collection_raises(self) -> None:
+        from anaconda_ai.clients.base import Model
+
+        mock_client = MagicMock()
+        mock_client.ai_config = MagicMock()
+
+        model = Model(
+            client=mock_client,
+            name="TestModel",
+            description="test",
+            num_parameters=1000,
+            trained_for="text-generation",
+            context_window_size=4096,
+            quantized_files=[],
+            collections=[],
+        )
+
+        with pytest.raises(QuantizedFileNotFound, match="No safetensors collection"):
+            model.get_collection("safetensors")
+
+
+class TestDownloadCollectionCatalyst:
+    def test_downloads_files_in_parallel(
+        self,
+        catalyst_models: AICatalystModels,
+        mock_catalyst_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        collection = _make_collection()
+        mock_model = MagicMock()
+        mock_model.name = "Qwen3-4B-Thinking-2507"
+        mock_model.get_collection.return_value = collection
+
+        catalyst_models.get = MagicMock(return_value=mock_model)
+
+        manifest_response = MagicMock()
+        manifest_response.json.return_value = SAMPLE_MANIFEST
+        manifest_response.raise_for_status = MagicMock()
+
+        file_url_response = MagicMock()
+        file_url_response.json.return_value = {
+            "download_url": "https://signed.example.com/file"
+        }
+        file_url_response.raise_for_status = MagicMock()
+
+        mock_catalyst_client.get.side_effect = [
+            manifest_response,
+            file_url_response,
+            file_url_response,
+        ]
+
+        mock_stream_response = MagicMock()
+        mock_stream_response.iter_content.return_value = [b"x" * 100]
+        mock_stream_response.raise_for_status = MagicMock()
+
+        with patch(
+            "anaconda_ai.clients.ai_catalyst.requests.get",
+            return_value=mock_stream_response,
+        ):
+            catalyst_models.download_collection(
+                "Qwen3-4B-Thinking-2507",
+                path=tmp_path,
+                show_progress=False,
+            )
+
+        assert (tmp_path / "model-00001-of-00002.safetensors").exists()
+        assert (tmp_path / "config.json").exists()
+
+    def test_skips_already_downloaded(
+        self,
+        catalyst_models: AICatalystModels,
+        mock_catalyst_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        collection = _make_collection()
+        mock_model = MagicMock()
+        mock_model.name = "Qwen3-4B-Thinking-2507"
+        mock_model.get_collection.return_value = collection
+
+        catalyst_models.get = MagicMock(return_value=mock_model)
+
+        manifest_response = MagicMock()
+        manifest_response.json.return_value = SAMPLE_MANIFEST
+        manifest_response.raise_for_status = MagicMock()
+
+        mock_catalyst_client.get.side_effect = [manifest_response]
+
+        (tmp_path / "model-00001-of-00002.safetensors").write_bytes(b"x" * 100)
+        (tmp_path / "config.json").write_bytes(b"y" * 100)
+
+        catalyst_models.download_collection(
+            "Qwen3-4B-Thinking-2507",
+            path=tmp_path,
+            show_progress=False,
+        )
+
+        assert mock_catalyst_client.get.call_count == 1
+
+    def test_size_mismatch_raises(
+        self,
+        catalyst_models: AICatalystModels,
+        mock_catalyst_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        collection = _make_collection()
+        mock_model = MagicMock()
+        mock_model.name = "Qwen3-4B-Thinking-2507"
+        mock_model.get_collection.return_value = collection
+
+        catalyst_models.get = MagicMock(return_value=mock_model)
+
+        manifest_response = MagicMock()
+        manifest_response.json.return_value = SAMPLE_MANIFEST
+        manifest_response.raise_for_status = MagicMock()
+
+        file_url_response = MagicMock()
+        file_url_response.json.return_value = {
+            "download_url": "https://signed.example.com/file"
+        }
+        file_url_response.raise_for_status = MagicMock()
+
+        mock_catalyst_client.get.side_effect = [
+            manifest_response,
+            file_url_response,
+            file_url_response,
+        ]
+
+        wrong_size_data = b"x" * 77
+        mock_stream_response = MagicMock()
+        mock_stream_response.iter_content.return_value = [wrong_size_data]
+        mock_stream_response.raise_for_status = MagicMock()
+
+        with patch(
+            "anaconda_ai.clients.ai_catalyst.requests.get",
+            return_value=mock_stream_response,
+        ):
+            with pytest.raises(RuntimeError, match="Size mismatch"):
+                catalyst_models.download_collection(
+                    "Qwen3-4B-Thinking-2507",
+                    path=tmp_path,
+                    show_progress=False,
+                )
+
+    def test_unpublished_raises(
+        self, catalyst_models: AICatalystModels, mock_catalyst_client: MagicMock
+    ) -> None:
+        collection = _make_collection()
+        collection.published = False
+
+        mock_model = MagicMock()
+        mock_model.name = "Qwen3-4B-Thinking-2507"
+        mock_model.get_collection.return_value = collection
+
+        catalyst_models.get = MagicMock(return_value=mock_model)
+
+        with pytest.raises(RuntimeError, match="not published"):
+            catalyst_models.download_collection("Qwen3-4B-Thinking-2507")
+
+
+class TestDownloadCollectionNavigator:
+    def test_raises_not_implemented(self) -> None:
+        mock_client = MagicMock()
+        nav_models = AINavigatorModels(mock_client)
+
+        with pytest.raises(NotImplementedError, match="ai-catalyst"):
+            nav_models.download_collection("SomeModel")
+
+
+class TestCLISafetensorsFlag:
+    def test_help_shows_safetensors(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(app, ["ai", "download", "--help"])
+        assert result.exit_code == 0
+        assert "--safetensors" in result.stdout
+
+    def test_rejects_quant_with_safetensors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+
+        with patch("anaconda_ai.cli.AnacondaAIClient") as mock_cls:
+            mock_client = MagicMock()
+            mock_client.models.download_collection.side_effect = ValueError(
+                "Model/Q4_K_M does not look like a model name."
+            )
+            mock_cls.return_value = mock_client
+            result = runner.invoke(
+                app, ["ai", "download", "--safetensors", "Model/Q4_K_M"]
+            )
+
+        assert result.exit_code == 1

--- a/tests/test_download_collection.py
+++ b/tests/test_download_collection.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 from uuid import UUID
 
@@ -65,7 +66,7 @@ def _make_regular_quant() -> AICatalystQuantizedFile:
     quant = AICatalystQuantizedFile(
         file_uuid=UUID("11111111-1111-1111-1111-111111111111"),
         model_uuid=UUID(SAMPLE_MODEL_UUID),
-        generated_on="2026-05-19T08:45:21Z",
+        generated_on=datetime(2026, 5, 19, 8, 45, 21, tzinfo=timezone.utc),
         quant_engine="llama.cpp",
         published=True,
         context_window_size=4096,
@@ -74,7 +75,6 @@ def _make_regular_quant() -> AICatalystQuantizedFile:
         quant_method="Q4_K_M",
         format="gguf",
         max_ram_usage=6000000,
-        is_collection=False,
     )
     mock_model = MagicMock()
     mock_model.name = "Qwen3-4B-Thinking-2507"
@@ -154,8 +154,6 @@ class TestDownloadCollectionCatalyst:
         mock_model.name = "Qwen3-4B-Thinking-2507"
         mock_model.get_collection.return_value = collection
 
-        catalyst_models.get = MagicMock(return_value=mock_model)
-
         manifest_response = MagicMock()
         manifest_response.json.return_value = SAMPLE_MANIFEST
         manifest_response.raise_for_status = MagicMock()
@@ -176,15 +174,16 @@ class TestDownloadCollectionCatalyst:
         mock_stream_response.iter_content.return_value = [b"x" * 100]
         mock_stream_response.raise_for_status = MagicMock()
 
-        with patch(
-            "anaconda_ai.clients.ai_catalyst.requests.get",
-            return_value=mock_stream_response,
-        ):
-            catalyst_models.download_collection(
-                "Qwen3-4B-Thinking-2507",
-                path=tmp_path,
-                show_progress=False,
-            )
+        with patch.object(catalyst_models, "get", return_value=mock_model):
+            with patch(
+                "anaconda_ai.clients.ai_catalyst.requests.get",
+                return_value=mock_stream_response,
+            ):
+                catalyst_models.download_collection(
+                    "Qwen3-4B-Thinking-2507",
+                    path=tmp_path,
+                    show_progress=False,
+                )
 
         assert (tmp_path / "model-00001-of-00002.safetensors").exists()
         assert (tmp_path / "config.json").exists()
@@ -200,8 +199,6 @@ class TestDownloadCollectionCatalyst:
         mock_model.name = "Qwen3-4B-Thinking-2507"
         mock_model.get_collection.return_value = collection
 
-        catalyst_models.get = MagicMock(return_value=mock_model)
-
         manifest_response = MagicMock()
         manifest_response.json.return_value = SAMPLE_MANIFEST
         manifest_response.raise_for_status = MagicMock()
@@ -211,11 +208,12 @@ class TestDownloadCollectionCatalyst:
         (tmp_path / "model-00001-of-00002.safetensors").write_bytes(b"x" * 100)
         (tmp_path / "config.json").write_bytes(b"y" * 100)
 
-        catalyst_models.download_collection(
-            "Qwen3-4B-Thinking-2507",
-            path=tmp_path,
-            show_progress=False,
-        )
+        with patch.object(catalyst_models, "get", return_value=mock_model):
+            catalyst_models.download_collection(
+                "Qwen3-4B-Thinking-2507",
+                path=tmp_path,
+                show_progress=False,
+            )
 
         assert mock_catalyst_client.get.call_count == 1
 
@@ -229,8 +227,6 @@ class TestDownloadCollectionCatalyst:
         mock_model = MagicMock()
         mock_model.name = "Qwen3-4B-Thinking-2507"
         mock_model.get_collection.return_value = collection
-
-        catalyst_models.get = MagicMock(return_value=mock_model)
 
         manifest_response = MagicMock()
         manifest_response.json.return_value = SAMPLE_MANIFEST
@@ -253,16 +249,17 @@ class TestDownloadCollectionCatalyst:
         mock_stream_response.iter_content.return_value = [wrong_size_data]
         mock_stream_response.raise_for_status = MagicMock()
 
-        with patch(
-            "anaconda_ai.clients.ai_catalyst.requests.get",
-            return_value=mock_stream_response,
-        ):
-            with pytest.raises(RuntimeError, match="Size mismatch"):
-                catalyst_models.download_collection(
-                    "Qwen3-4B-Thinking-2507",
-                    path=tmp_path,
-                    show_progress=False,
-                )
+        with patch.object(catalyst_models, "get", return_value=mock_model):
+            with patch(
+                "anaconda_ai.clients.ai_catalyst.requests.get",
+                return_value=mock_stream_response,
+            ):
+                with pytest.raises(RuntimeError, match="Size mismatch"):
+                    catalyst_models.download_collection(
+                        "Qwen3-4B-Thinking-2507",
+                        path=tmp_path,
+                        show_progress=False,
+                    )
 
     def test_unpublished_raises(
         self, catalyst_models: AICatalystModels, mock_catalyst_client: MagicMock
@@ -274,10 +271,9 @@ class TestDownloadCollectionCatalyst:
         mock_model.name = "Qwen3-4B-Thinking-2507"
         mock_model.get_collection.return_value = collection
 
-        catalyst_models.get = MagicMock(return_value=mock_model)
-
-        with pytest.raises(RuntimeError, match="not published"):
-            catalyst_models.download_collection("Qwen3-4B-Thinking-2507")
+        with patch.object(catalyst_models, "get", return_value=mock_model):
+            with pytest.raises(RuntimeError, match="not published"):
+                catalyst_models.download_collection("Qwen3-4B-Thinking-2507")
 
 
 class TestDownloadCollectionNavigator:


### PR DESCRIPTION
The first collection type is `safetensors` that apply to the model itself, not individual quantizations.

<img width="855" height="326" alt="Screenshot 2026-05-20 at 13 45 49" src="https://github.com/user-attachments/assets/763c47fe-79ef-4ab6-ad56-6097aeb699d7" />

All files defined in the collection will be downloaded with a concurrency of 5 into the current working directory or a chosen directory with `--output` flag.