### PR TITLE
test(cli): [AIC-3566] update anaconda ai cli command coverage

### DIFF
--- a/tests/e2e/pages/cli/anaconda-ai-cmds.ts
+++ b/tests/e2e/pages/cli/anaconda-ai-cmds.ts
@@ -65,8 +65,8 @@ export class AnacondaAiCli {
     expect(status, `Expected server status to be "running"`).toBe('running');
   }
 
-  // Executes `anaconda ai download <model>/<quant>` (positional; no --model)
-  public async runDownloadModelCommand(modelName: string, modelQuantization: string): Promise<ShellResult> {
+  // Executes `anaconda ai download <model>` or `anaconda ai download <model>/<quant>`
+  public async runDownloadModelCommand(modelName: string, modelQuantization?: string): Promise<ShellResult> {
     return await shellCommand(cliCommands.downloadModelCmd(modelName, modelQuantization));
   }
 
@@ -87,13 +87,24 @@ export class AnacondaAiCli {
     ).toBeTruthy();
   }
 
-  public verifyInvalidDownloadModelCommand(result: ShellResult): void {
-    expect(result.exitCode, `Expected invalid download command to fail, but got exit code ${result.exitCode}`).not.toBe(
-      0,
-    );
+  // Validates download fails when quantization is missing or invalid (ValueError)
+  public verifyDownloadMissingQuantizationCommand(result: ShellResult): void {
+    expect(result.exitCode, 'Expected download without valid quantization to fail').not.toBe(0);
+
     const output = stripAnsiSgrAndTrim(result.output).toLowerCase();
-    expect(output, 'Expected the model to be invalid').toContain('error');
-    expect(output, 'Expected output should contain invalid model error message').toContain(INVALID_MODEL_ERROR_MESSAGE);
+    expect(output.includes('valueerror'), 'Expected ValueError in output').toBeTruthy();
+    expect(output, 'Expected quantization format error message').toContain(INVALID_MODEL_ERROR_MESSAGE);
+  }
+
+  // Validates download fails when model name is not found
+  public verifyDownloadModelNotFoundCommand(result: ShellResult): void {
+    expect(result.exitCode, 'Expected non-zero exit code for unknown model download').not.toBe(0);
+
+    const output = stripAnsiSgrAndTrim(result.output).toLowerCase();
+    expect(
+      output.includes('modelnotfound') || output.includes('was not found'),
+      'Expected ModelNotFound error for unknown model download',
+    ).toBeTruthy();
   }
 
   // Executes `anaconda ai launch <model>/<quant> --detach`

--- a/tests/e2e/pages/cli/cliCommands.ts
+++ b/tests/e2e/pages/cli/cliCommands.ts
@@ -1,7 +1,7 @@
 // Anaconda AI package CLI commands
 
-const anacondaAiChannel = process.env.ANACONDA_AI_CHANNEL ?? 'anaconda-cloud/label/dev';
-const anacondaAiVersion = process.env.ANACONDA_AI_VERSION ?? '0.5.0';
+const anacondaAiChannel = process.env.ANACONDA_AI_CHANNEL ?? 'anaconda-cloud';
+const anacondaAiVersion = process.env.ANACONDA_AI_VERSION ?? '0.7.0';
 
 // Run all command in the anaconda-cli environment
 const condaRun = (inner: string): string => `conda run -n anaconda-cli --no-capture-output ${inner}`;
@@ -34,8 +34,12 @@ export const anacondaAiModelsListCmd = condaRun('anaconda ai models --json');
 export const anacondaAiBlockedModelsListCmd = condaRun('anaconda ai models --show-blocked --json');
 
 // Download Model Command
-export const downloadModelCmd = (modelName: string, modelQuantization: string): string =>
-  condaRun(`anaconda ai download ${modelName}/${modelQuantization}`);
+export const downloadModelCmd = (modelName: string, modelQuantization?: string): string =>
+  condaRun(
+    modelQuantization === undefined
+      ? `anaconda ai download ${modelName}`
+      : `anaconda ai download ${modelName}/${modelQuantization}`,
+  );
 
 // Anaconda AI Servers Command
 export const anacondaAiServersListCmd = condaRun('anaconda ai servers --json');

--- a/tests/e2e/specs/cli/anaconda-ai.spec.ts
+++ b/tests/e2e/specs/cli/anaconda-ai.spec.ts
@@ -45,6 +45,11 @@ test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
     anacondaAiCli.verifyDownloadMissingQuantizationCommand(result);
   });
 
+  test('anaconda ai download - unknown model returns ModelNotFound', async ({ anacondaAiCli }) => {
+    const result = await anacondaAiCli.runDownloadModelCommand(INVALID_MODEL_NAME, DOWNLOAD_TEST_MODEL_QUANTIZATION);
+    anacondaAiCli.verifyDownloadModelNotFoundCommand(result);
+  });
+
   test('anaconda ai servers list command', async ({ anacondaAiCli }) => {
     const result = await anacondaAiCli.runAnacondaAiServersListCommand();
     anacondaAiCli.verifyAnacondaAiServersListCommand(result);

--- a/tests/e2e/specs/cli/anaconda-ai.spec.ts
+++ b/tests/e2e/specs/cli/anaconda-ai.spec.ts
@@ -36,7 +36,7 @@ test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
   });
 
   test('anaconda ai download - missing quantization returns ValueError', async ({ anacondaAiCli }) => {
-    const result = await anacondaAiCli.runDownloadModelCommand(INVALID_MODEL_NAME);
+    const result = await anacondaAiCli.runDownloadModelCommand(DOWNLOAD_TEST_MODEL_NAME);
     anacondaAiCli.verifyDownloadMissingQuantizationCommand(result);
   });
 

--- a/tests/e2e/specs/cli/anaconda-ai.spec.ts
+++ b/tests/e2e/specs/cli/anaconda-ai.spec.ts
@@ -7,12 +7,12 @@ import {
 } from '@testdata/model-api';
 
 test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
-  test('anaconda ai version command', async ({ anacondaAiCli }) => {
+  test('anaconda ai version command @smoke', async ({ anacondaAiCli }) => {
     const result = await anacondaAiCli.runAnacondaAiVersionCommand();
     anacondaAiCli.verifyAnacondaAiVersionCommand(result);
   });
 
-  test('anaconda ai --help', async ({ anacondaAiCli }) => {
+  test('anaconda ai --help @smoke', async ({ anacondaAiCli }) => {
     const result = await anacondaAiCli.runAnacondaAiHelpCommand();
     anacondaAiCli.verifyAnacondaAiHelpCommand(result);
   });
@@ -35,9 +35,14 @@ test.describe('Anaconda AI CLI Commands @anaconda-ai', () => {
     anacondaAiCli.verifyDownloadModelCommand(result);
   });
 
-  test('anaconda ai download invalid model command', async ({ anacondaAiCli }) => {
-    const result = await anacondaAiCli.runDownloadModelCommand(INVALID_MODEL_NAME, INVALID_MODEL_QUANTIZATION);
-    anacondaAiCli.verifyInvalidDownloadModelCommand(result);
+  test('anaconda ai download - missing quantization returns ValueError', async ({ anacondaAiCli }) => {
+    const result = await anacondaAiCli.runDownloadModelCommand(INVALID_MODEL_NAME);
+    anacondaAiCli.verifyDownloadMissingQuantizationCommand(result);
+  });
+
+  test('anaconda ai download - invalid quantization returns ValueError', async ({ anacondaAiCli }) => {
+    const result = await anacondaAiCli.runDownloadModelCommand(DOWNLOAD_TEST_MODEL_NAME, INVALID_MODEL_QUANTIZATION);
+    anacondaAiCli.verifyDownloadMissingQuantizationCommand(result);
   });
 
   test('anaconda ai servers list command', async ({ anacondaAiCli }) => {


### PR DESCRIPTION
## Summary

This PR updates the Anaconda AI CLI automation coverage to align with the latest CLI package and command behavior.

## Changes

- Updated the default Anaconda AI CLI package configuration:
  - Channel updated from `anaconda-cloud/label/dev` to `anaconda-cloud`
  - Version updated from `0.5.0` to `0.7.0`
- Updated the download command helper to support both command formats:
  - `anaconda ai download <model>`
  - `anaconda ai download <model>/<quantization>`
- Added separate validation methods for download failure scenarios:
  - Missing quantization / invalid quantization returning `ValueError`
  - Unknown model returning model-not-found error
- Updated CLI tests for invalid download scenarios.
- Added `@smoke` tag to the version and help command tests.

## Files Changed

- `tests/e2e/pages/cli/anaconda-ai-cmds.ts`
- `tests/e2e/pages/cli/cliCommands.ts`
- `tests/e2e/specs/cli/anaconda-ai.spec.ts`

## Testing

- Verified CLI command helpers are updated with the latest expected command format.
- Verified negative download scenarios are covered separately for missing/invalid quantization and invalid model name.
- Added smoke coverage for basic CLI version and help commands.

## Jira

AIC-3566