### PR TITLE
chore(anaconda-ai): [AIC-3577] add Claude code review workflow

### DIFF
--- a/.github/workflows/bot-code-review.yml
+++ b/.github/workflows/bot-code-review.yml
@@ -1,0 +1,29 @@
+# Delegates @claude PR reviews to the org reusable workflow (internal-actions).
+name: '[Bot] Code Review'
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  claude-code-review:
+    name: Claude Code Review
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      actions: read
+    if: |
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+    uses: anaconda/internal-actions/.github/workflows/bot-code-review.yml@1be176d1d4801c4ca716ffaf646726200b60e82f # main
+    with:
+      team: qa


### PR DESCRIPTION
# [AIC-3577](https://anaconda.atlassian.net/browse/AIC-3577)

## Description

### What does this PR do?

This PR adds the Claude code review workflow under GitHub Workflows for the `anaconda-ai` repository.

### Why are these changes needed?

The QA team is rolling out the Claude code review workflow across repositories to provide automated code review support on pull requests and review-related events. This change enables the same workflow for the `anaconda-ai` repository.

### Related issues

- AIC-3577

## Type of Change

### Please check the type of change your PR introduces

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] Miscellaneous

## How Has This Been Tested?

### Describe the tests that you ran to verify your changes

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe)

### Testing steps

1. Added `.github/workflows/bot-code-review.yml`.
2. Verified the workflow file is present in the `.github/workflows` directory.
3. Confirmed the workflow configuration matches the reusable Claude code review workflow pattern used in other repositories.
4. Verified the workflow is recognized by GitHub Actions after pushing the branch.

## Checklist

### Before submitting this PR, please make sure

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have updated or added tests for my changes.
- [ ] I have run and passed the PR checks locally.
- [ ] I have added the `data-qa-id` attribute to any UI elements that QA would need to identify and interact with.

## Screenshots (if applicable)

N/A

## Additional Comments

This change is part of the QA team's initiative to enable Claude code review workflows across repositories.

[AIC-3577]: https://anaconda.atlassian.net/browse/AIC-3577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ