### PR TITLE
deprecated ai-navigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ The available backends are
 
 |Backend name|Configuration value|Supports|Default|
 |------------|-------------------|--------|-------|
-|[Anaconda AI Navigator](https://www.anaconda.com/products/ai-navigator)|`"ai-navigator"`|Models,Servers,Server Parameters,VectorDB|DEFAULT|
+|[Anaconda Desktop](https://www.anaconda.com/docs/anaconda-desktop/install-desktop)|`"anaconda-desktop"`|Models,Servers,Server Parameters|DEFAULT|
+|[Anaconda AI Navigator](https://www.anaconda.com/products/ai-navigator)|`"ai-navigator"`|Models,Servers,Server Parameters,VectorDB|DEPRECATED|
 |Anaconda AI Catalyst|`"ai-catalyst"`|Models,Servers,Multi-Site||
 
 ## Configuration
@@ -45,7 +46,7 @@ Anaconda AI supports configuration management in the `~/.anaconda/config.toml` f
 
 |Parameter|Environment variable|Description|Default value|
 |---------|--------------------|-----------|-------------|
-|`backend`|`ANACONDA_AI_BACKEND`|The backend API|`"ai-navigator"`|
+|`backend`|`ANACONDA_AI_BACKEND`|The backend API|`"anaconda-desktop"`|
 |`stop_server_on_exit`|`ANACONDA_AI_STOP_SERVER_ON_EXIT`|For any server started during a Python interpreter session stop the server when the interpreter stops. Does not affect servers that were previously running|`true`|
 |`server_operations_timeout`|`ANACONDA_AI_SERVER_OPERATIONS_TIMEOUT`|Timeout waiting for a server to start or stop|`30`|
 |`show_blocked_models`|`ANACONDA_AI_SHOW_BLOCKED_MODELS`|Toggle display of blocked models if backend supports it|`false`|
@@ -107,7 +108,7 @@ client = AnacondaAIClient()
 
 |Argument|Type|Description|Default|
 |---|---|---|---|
-|`backend`|str|The backend to use, see [Backends](#backends)|`"ai-navigator"`|
+|`backend`|str|The backend to use, see [Backends](#backends)|`"anaconda-desktop"`|
 |`stop_server_on_exit`|bool|Stop servers started in this session when the Python interpreter exits|`True`|
 |`server_operations_timeout`|int|Timeout in seconds waiting for a server to start or stop|`30`|
 
@@ -320,7 +321,7 @@ client initialization.
 
 Not all backends support `extra_options=` on server create.
 
-The AI Navigator backend supports [llama-server options](https://github.com/ggml-org/llama.cpp/tree/master/tools/server#usage)
+The Anaconda Desktop backend supports [llama-server options](https://github.com/ggml-org/llama.cpp/tree/master/tools/server#usage)
 passed as snake-case dictionary keys to `client.servers.create()` with the `extra_options` kwarg.
 To enable flags set the value to `True`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ raw-options.local_scheme = "no-local-version"
 
 [tool.mypy]
 disallow_untyped_defs = true
+exclude = ["numpy"]
 files = [
   "src/**/*.py",
   "tests/**/*.py"
@@ -131,6 +132,7 @@ module = "ruamel.*"
 
 [[tool.mypy.overrides]]
 follow_imports = "skip"
+follow_imports_for_stubs = true
 module = "numpy.*"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,10 @@ module = "botocore.*"
 ignore_missing_imports = true
 module = "ruamel.*"
 
+[[tool.mypy.overrides]]
+follow_imports = "skip"
+module = "numpy.*"
+
 [tool.pytest.ini_options]
 addopts = [
   "--cov=anaconda_ai",

--- a/src/anaconda_ai/clients/__init__.py
+++ b/src/anaconda_ai/clients/__init__.py
@@ -42,8 +42,10 @@ class AnacondaAIClient(GenericClient):
         server_operations_timeout: Optional[int] = None,
         **kwargs: Any,
     ):
+        resolved_backend = backend or AnacondaAIConfig().backend
+
         try:
-            self.__class__ = clients[backend or AnacondaAIConfig().backend]
+            self.__class__ = clients[resolved_backend]
         except KeyError:
             raise UnknownBackendError(f"There is no known backend called {backend}")
 

--- a/src/anaconda_ai/clients/ai_navigator.py
+++ b/src/anaconda_ai/clients/ai_navigator.py
@@ -3,6 +3,7 @@ from time import time, sleep
 from typing import Dict, List, Optional, Any, Union, Generator, Sequence, Set
 from typing_extensions import Self
 from urllib.parse import quote
+from warnings import warn
 
 from pydantic import Field, computed_field, ConfigDict, model_validator, BaseModel
 from rich.console import Console
@@ -433,6 +434,15 @@ class AINavigatorClient(GenericClient):
         app_name: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
+        warn(
+            "The 'ai-navigator' backend is deprecated. "
+            "Please migrate to 'anaconda-desktop'. "
+            "Download Anaconda Desktop at: "
+            "https://www.anaconda.com/docs/anaconda-desktop/install-desktop",
+            FutureWarning,
+            stacklevel=2,
+        )
+
         ai_kwargs: Dict[str, Any] = {"backends": {"ai_navigator": {}}}
         if app_name is not None:
             ai_kwargs["backends"]["ai_navigator"]["app_name"] = app_name

--- a/src/anaconda_ai/clients/anaconda_desktop.py
+++ b/src/anaconda_ai/clients/anaconda_desktop.py
@@ -7,6 +7,7 @@ from ..config import AnacondaAIConfig
 from ..exceptions import ProjectsAPIError, SystemPromptNotFoundError
 from .base import (
     BaseSystemPrompts,
+    BaseVectorDb,
     GenericClient,
     PromptListResponse,
     PromptSummary,
@@ -15,7 +16,6 @@ from .base import (
 from .ai_navigator import (
     AINavigatorModels,
     AINavigatorServers,
-    AINavigatorVectorDbServer,
     AiNavigatorVersion,
 )
 
@@ -33,7 +33,7 @@ def _derive_prompt_name(project_name: str) -> str:
 class AnacondaDesktopSystemPrompts(BaseSystemPrompts):
     """System prompt operations via the Anaconda Platform Collections API.
 
-    Unlike models/servers/vector_db (which reuse AINavigator classes),
+    Unlike models/servers (which reuse AINavigator classes),
     this class talks directly to the cloud Projects API because
     AINavigator does not support system prompts.
 
@@ -152,7 +152,7 @@ class AnacondaDesktopClient(GenericClient):
 
         self.models = AINavigatorModels(self)
         self.servers = AINavigatorServers(self)
-        self.vector_db = AINavigatorVectorDbServer(self)
+        self.vector_db = BaseVectorDb(self)
         # System prompts use the cloud Projects API (not AINavigator's local API),
         # so they need a cloud-authenticated client rather than the desktop one.
         self.system_prompts = AnacondaDesktopSystemPrompts(AuthBaseClient())

--- a/src/anaconda_ai/config.py
+++ b/src/anaconda_ai/config.py
@@ -98,7 +98,9 @@ class Stage(BaseModel):
 class AnacondaAIConfig(AnacondaBaseSettings, plugin_name="ai"):
     backends: Backends = Field(default_factory=Backends)
     stage: Stage = Field(default_factory=Stage)
-    backend: Literal["ai-catalyst", "ai-navigator", "anaconda-desktop"] = "ai-navigator"
+    backend: Literal["ai-catalyst", "ai-navigator", "anaconda-desktop"] = (
+        "anaconda-desktop"
+    )
     stop_server_on_exit: bool = True
     server_operations_timeout: int = 60
     show_blocked_models: bool = False

--- a/src/anaconda_ai/integrations/instructor.py
+++ b/src/anaconda_ai/integrations/instructor.py
@@ -122,4 +122,4 @@ def from_provider(
         )
 
 
-instructor.from_provider = from_provider
+instructor.from_provider = from_provider  # type: ignore[assignment]

--- a/src/anaconda_ai/integrations/pydantic_ai.py
+++ b/src/anaconda_ai/integrations/pydantic_ai.py
@@ -87,7 +87,9 @@ class AnacondaChatModel(OpenAIChatModel, AnacondaMixin):
         )
         object.__setattr__(self, "client", openai_client)
 
-        self.profile = AnacondaModelProfile().update(self.profile)
+        profile = AnacondaModelProfile()
+        profile.update(self.profile)
+        self.profile = profile
 
 
 class AnacondaEmbeddingSettings(OpenAIEmbeddingSettings, total=False):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,9 +3,8 @@ from typing import Any
 from typing import Protocol
 
 import pytest
-from click.testing import Result
 from pytest import MonkeyPatch
-from typer.testing import CliRunner
+from typer.testing import CliRunner, Result
 
 from anaconda_cli_base.cli import app
 


### PR DESCRIPTION
anaconda-ai will be an allowed backend for some time but is no longer the default, removed from docs, and will throw a warning.


```
❯ anaconda ai models --backend ai-navigator
/Users/adefusco/Development/anaconda/anaconda-ai/src/anaconda_ai/clients/__init__.py:52: FutureWarning: The 'ai-navigator' backend is deprecated. Please migrate to 'anaconda-desktop'. Download Anaconda Desktop at: https://www.anaconda.com/docs/anaconda-desktop/install-desktop
  self.__init__(  # type: ignore
```